### PR TITLE
Add controls to manage past workout logs

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -29,6 +29,7 @@ if (typeof document !== 'undefined') {
     const calGo = document.getElementById('calGo');
     const pasteJson = document.getElementById('pasteJson');
     const importFromPaste = document.getElementById('importFromPaste');
+    const clearDayBtn = document.getElementById('clearDay');
 
     function updateDateInput(){
       calGoto.value = selectedDate;
@@ -122,8 +123,19 @@ if (typeof document !== 'undefined') {
       const list = history[selectedDate] || [];
       list.forEach((text, idx) => {
         const li = document.createElement('li');
-        li.textContent = text;
-        li.addEventListener('click', () => {
+        li.className = 'entry-item';
+
+        const span = document.createElement('span');
+        span.textContent = text;
+        li.appendChild(span);
+
+        const actions = document.createElement('div');
+        actions.className = 'entry-actions';
+
+        const editBtn = document.createElement('button');
+        editBtn.textContent = 'Edit';
+        editBtn.className = 'btn-mini edit';
+        editBtn.addEventListener('click', () => {
           const updated = prompt('Edit entry', text);
           if(updated !== null){
             history[selectedDate][idx] = updated.trim();
@@ -134,8 +146,12 @@ if (typeof document !== 'undefined') {
             renderCalendar();
           }
         });
-        li.addEventListener('contextmenu', e => {
-          e.preventDefault();
+        actions.appendChild(editBtn);
+
+        const delBtn = document.createElement('button');
+        delBtn.textContent = 'Del';
+        delBtn.className = 'btn-mini del';
+        delBtn.addEventListener('click', () => {
           if(confirm('Delete entry?')){
             history[selectedDate].splice(idx,1);
             if(history[selectedDate].length === 0) delete history[selectedDate];
@@ -144,8 +160,14 @@ if (typeof document !== 'undefined') {
             renderCalendar();
           }
         });
+        actions.appendChild(delBtn);
+
+        li.appendChild(actions);
         entriesEl.appendChild(li);
       });
+      if(clearDayBtn){
+        clearDayBtn.disabled = list.length === 0;
+      }
       updateDateInput();
     }
     addEntryBtn.addEventListener('click', () => {
@@ -158,6 +180,26 @@ if (typeof document !== 'undefined') {
       renderDay();
       renderCalendar();
     });
+
+    if(clearDayBtn){
+      const handleClearDay = e => {
+        e.preventDefault();
+        console.log('Clear Day clicked for', selectedDate);
+        if(!history[selectedDate] || !history[selectedDate].length) return;
+        if(confirm('Clear all entries for this day?')){
+          delete history[selectedDate];
+          save();
+          renderDay();
+          renderCalendar();
+        }
+      };
+      clearDayBtn.addEventListener('click', handleClearDay);
+      clearDayBtn.addEventListener('keyup', e => {
+        if(e.key === 'Enter' || e.key === ' '){
+          handleClearDay(e);
+        }
+      });
+    }
 
     exportBtn.addEventListener('click', () => {
       const data = JSON.stringify(history, null, 2);

--- a/calendar.js
+++ b/calendar.js
@@ -182,6 +182,7 @@ if (typeof document !== 'undefined') {
     });
 
     if(clearDayBtn){
+      // Shared handler ensures desktop and mobile clicks behave consistently
       const handleClearDay = e => {
         e.preventDefault();
         if(!history[selectedDate] || !history[selectedDate].length) return;

--- a/calendar.js
+++ b/calendar.js
@@ -289,9 +289,21 @@ if (typeof document !== 'undefined') {
       let target = selectedDate;
       const header = lines[0].match(/WORKOUT DATA - (\d{4}-\d{2}-\d{2})/);
       if(header) target = header[1];
-      const regex = /^\s*(Set\s+\d+\s*[-–]\s*)?.+?:\s*\d+(?:\.\d+)?\s*(?:lbs|kg)\s*[×x]\s*\d+\s*reps.*$/i;
+      let current = '';
       const out = [];
-      lines.forEach(l=>{ if(regex.test(l)) out.push(l.trim()); });
+      const exRegex = /^\s*([^:]+):\s*$/;
+      const setRegex = /^\s*Set\s*\d+\s*:\s*(\d+(?:\.\d+)?)\s*(lbs|kg)\s*[×x]\s*(\d+)\s*reps/i;
+      lines.forEach(line => {
+        const ex = line.match(exRegex);
+        if(ex){
+          current = ex[1].trim();
+          return;
+        }
+        const set = line.match(setRegex);
+        if(set && current){
+          out.push(`${current}: ${set[1]} ${set[2]} × ${set[3]} reps`);
+        }
+      });
       if(out.length){
         return {[target]: out};
       }

--- a/calendar.js
+++ b/calendar.js
@@ -184,7 +184,6 @@ if (typeof document !== 'undefined') {
     if(clearDayBtn){
       const handleClearDay = e => {
         e.preventDefault();
-        console.log('Clear Day clicked for', selectedDate);
         if(!history[selectedDate] || !history[selectedDate].length) return;
         if(confirm('Clear all entries for this day?')){
           delete history[selectedDate];

--- a/index.html
+++ b/index.html
@@ -104,6 +104,7 @@
             <input type="text" id="entryInput" class="field" placeholder="Add workout note">
             <button id="addEntry" class="btn btn-secondary" style="flex:0 0 80px;">Add</button>
           </div>
+          <button id="clearDay" type="button" class="btn btn-reset" style="margin-top:8px;">Clear Day</button>
         </div>
         <div class="history-actions">
           <button id="saveTodaySession" class="btn btn-secondary">Save Today from Session</button>

--- a/style.css
+++ b/style.css
@@ -200,6 +200,9 @@ body.dark #calendarSection{
 .day-details{border:1px solid #e6eaef;border-radius:8px;padding:10px;margin-bottom:12px;}
 .day-details h4{margin-bottom:8px;}
 .day-details ul{list-style:disc;margin-left:20px;margin-bottom:8px;}
+.entry-item{display:flex;justify-content:space-between;align-items:center;gap:6px;margin-bottom:4px;}
+.entry-item span{flex:1;}
+.entry-actions{display:flex;gap:6px;}
 .history-actions{display:flex;gap:8px;flex-wrap:wrap;}
 .calendar-controls{display:flex;gap:8px;margin-bottom:8px;}
 .calendar-controls #calGoto{flex:1;min-width:120px;}


### PR DESCRIPTION
## Summary
- Add **Clear Day** button to remove all entries for a selected date
- Provide explicit Edit/Del buttons for past entries and disable Clear Day when empty
- Style calendar day entries for new action buttons
- Ensure Clear Day handler fires on desktop with debug logging and keyboard support
- Explicitly mark Clear Day button as type="button" to avoid unwanted submission behavior

## Testing
- `npm test` *(fails: Directory /workspace/Workout-Tracker/tests in the roots[0] option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68900b1f3a0083329d68d2a5a44c0c97