### PR TITLE
Add offline fallback for exercise list

### DIFF
--- a/data/exercises.js
+++ b/data/exercises.js
@@ -1,0 +1,41 @@
+const exercises = [
+  {"name":"Bench Press","category":"Chest","equipment":"Barbell"},
+  {"name":"Incline Bench Press","category":"Chest","equipment":"Barbell"},
+  {"name":"Push Up","category":"Chest","equipment":"Bodyweight"},
+  {"name":"Dumbbell Fly","category":"Chest","equipment":"Dumbbell"},
+  {"name":"Chest Dip","category":"Chest","equipment":"Bodyweight"},
+  {"name":"Squat","category":"Legs","equipment":"Barbell"},
+  {"name":"Front Squat","category":"Legs","equipment":"Barbell"},
+  {"name":"Leg Press","category":"Legs","equipment":"Machine"},
+  {"name":"Calf Raise","category":"Legs","equipment":"Machine"},
+  {"name":"Hamstring Curl","category":"Legs","equipment":"Machine"},
+  {"name":"Hip Thrust","category":"Legs","equipment":"Barbell"},
+  {"name":"Overhead Squat","category":"Legs","equipment":"Barbell"},
+  {"name":"Deadlift","category":"Back","equipment":"Barbell"},
+  {"name":"Bent Over Row","category":"Back","equipment":"Barbell"},
+  {"name":"Good Morning","category":"Back","equipment":"Barbell"},
+  {"name":"Pull Up","category":"Back","equipment":"Bodyweight"},
+  {"name":"Lat Pulldown (Overhand)","category":"Back","equipment":"Machine"},
+  {"name":"Lat Pulldown (Underhand)","category":"Back","equipment":"Machine"},
+  {"name":"Shoulder Press","category":"Shoulders","equipment":"Dumbbell"},
+  {"name":"Lateral Raise","category":"Shoulders","equipment":"Dumbbell"},
+  {"name":"Bicep Curl","category":"Arms","equipment":"Dumbbell"},
+  {"name":"Barbell Curl","category":"Arms","equipment":"Barbell"},
+  {"name":"Tricep Pushdown","category":"Arms","equipment":"Cable"},
+  {"name":"Skull Crusher","category":"Arms","equipment":"Barbell"},
+  {"name":"Crunch","category":"Core","equipment":"Bodyweight"},
+  {"name":"Plank","category":"Core","equipment":"Bodyweight"},
+  {"name":"Russian Twist","category":"Core","equipment":"Bodyweight"},
+  {"name":"Running","category":"Cardio","equipment":"None"},
+  {"name":"Cycling","category":"Cardio","equipment":"Machine"},
+  {"name":"Jump Rope","category":"Cardio","equipment":"Rope"}
+];
+
+if (typeof window !== 'undefined') {
+  window.exercisesFallback = exercises;
+}
+
+// For Node/CommonJS environments
+if (typeof module !== 'undefined') {
+  module.exports = exercises;
+}

--- a/index.html
+++ b/index.html
@@ -131,6 +131,7 @@
     <span id="themeLabel">Dark</span>
   </button>
 
+<script src="data/exercises.js"></script>
 <script src="script.js"></script>
 <script src="calendar.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -55,10 +55,11 @@ let allExercises = [];
 async function loadExercises(){
   try {
     const res = await fetch('data/exercises.json');
+    if(!res.ok) throw new Error('HTTP '+res.status);
     allExercises = await res.json();
   } catch (err) {
-    console.error('Failed to load exercises', err);
-    allExercises = [];
+    console.error('Failed to load exercises via fetch', err);
+    allExercises = window.exercisesFallback || [];
   }
   const custom = JSON.parse(localStorage.getItem('custom_exercises')) || [];
   custom.forEach(n => allExercises.push({ name: n, category: 'Custom', equipment: '', custom: true }));
@@ -79,39 +80,26 @@ function populateMuscleFilter(){
 
 function renderExerciseOptions(){
   exerciseSelect.innerHTML = '<option value="">Select Exercise</option>';
+  const q = exerciseSearch.value.trim().toLowerCase();
+  const cat = muscleFilter.value;
   const groups = {};
   allExercises.forEach(ex => {
+    if(cat && ex.category !== cat) return;
+    if(q && !ex.name.toLowerCase().includes(q)) return;
     if(!groups[ex.category]) groups[ex.category] = [];
     groups[ex.category].push(ex);
   });
-  Object.keys(groups).sort().forEach(cat => {
+  Object.keys(groups).sort().forEach(catName => {
     const og = document.createElement('optgroup');
-    og.label = cat;
-    groups[cat].sort((a,b)=>a.name.localeCompare(b.name)).forEach(ex => {
+    og.label = catName;
+    groups[catName].sort((a,b)=>a.name.localeCompare(b.name)).forEach(ex => {
       const opt = document.createElement('option');
       opt.value = ex.name;
       opt.textContent = ex.name;
-      opt.dataset.category = cat;
+      opt.dataset.category = ex.category;
       og.appendChild(opt);
     });
     exerciseSelect.appendChild(og);
-  });
-  filterExercises();
-}
-
-function filterExercises(){
-  const q = exerciseSearch.value.trim().toLowerCase();
-  const cat = muscleFilter.value;
-  const groups = exerciseSelect.querySelectorAll('optgroup');
-  groups.forEach(g => {
-    let show = false;
-    Array.from(g.children).forEach(opt => {
-      const matchQ = opt.textContent.toLowerCase().includes(q);
-      const matchC = !cat || opt.dataset.category === cat;
-      opt.hidden = !(matchQ && matchC);
-      if(!opt.hidden) show = true;
-    });
-    g.hidden = !show;
   });
 }
 
@@ -120,8 +108,8 @@ function saveCustomExercises(){
   localStorage.setItem('custom_exercises', JSON.stringify(custom));
 }
 
-exerciseSearch.addEventListener('input', filterExercises);
-muscleFilter.addEventListener('change', filterExercises);
+exerciseSearch.addEventListener('input', renderExerciseOptions);
+muscleFilter.addEventListener('change', renderExerciseOptions);
 
 loadExercises();
 
@@ -161,11 +149,11 @@ addExerciseBtn.addEventListener('click', () => {
     populateMuscleFilter();
     renderExerciseOptions();
   }
-  exerciseSelect.value = name;
-  customExerciseInput.value = '';
   exerciseSearch.value='';
   muscleFilter.value='';
-  filterExercises();
+  renderExerciseOptions();
+  exerciseSelect.value = name;
+  customExerciseInput.value = '';
   startExercise(name);
 });
 
@@ -182,7 +170,7 @@ startSupersetBtn.addEventListener('click', () => {
   if(!supersetBuilder.classList.contains('hidden')){
     exerciseSearch.value='';
     muscleFilter.value='';
-    filterExercises();
+    renderExerciseOptions();
     populateSupersetSelects();
   }
 });
@@ -203,7 +191,7 @@ exerciseSelect.addEventListener('change', e => {
   if(e.target.value){
     exerciseSearch.value='';
     muscleFilter.value='';
-    filterExercises();
+    renderExerciseOptions();
     startExercise(e.target.value);
   }
 });


### PR DESCRIPTION
## Summary
- Ensure exercise list still populates when `fetch` of `exercises.json` fails (e.g., on desktop `file://` URLs) by importing a JS module as fallback
- Provide `data/exercises.js` module with default exercise array
- Rebuild exercise dropdown on filter changes so selecting a category shows only its exercises

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893cc260650833289b59913bcfa09e4