### PR TITLE
Allow Jump Rope cardio without distance

### DIFF
--- a/script.js
+++ b/script.js
@@ -15,8 +15,15 @@ function canLogSet(w, r){
   return !Number.isNaN(w) && !Number.isNaN(r) && r > 0;
 }
 
-function canLogCardio(d, t){
-  return !Number.isNaN(d) && d >= 0 && !Number.isNaN(t) && t > 0;
+function canLogCardio(d, t, name){
+  const durOk = !Number.isNaN(t) && t > 0;
+  const distMissing = d == null || Number.isNaN(d);
+  if(name === 'Jump Rope'){
+    const distOk = distMissing || d >= 0;
+    return distOk && durOk;
+  }
+  const distOk = !distMissing && d >= 0;
+  return distOk && durOk;
 }
 
 /* ------------------ ELEMENTS ------------------ */
@@ -330,10 +337,11 @@ logBtn.addEventListener('click', function(){
   }
 
   if(currentExercise.isCardio){
-    const d = parseFloat(distanceInput.value);
+    const rawD = parseFloat(distanceInput.value);
+    const d = distanceInput.value === '' ? null : rawD;
     const t = parseInt(durationInput.value, 10);
-    if(!canLogCardio(d, t)){
-      alert('Enter distance & duration');
+    if(!canLogCardio(d, t, currentExercise.name)){
+      alert(currentExercise.name === 'Jump Rope' ? 'Enter duration' : 'Enter distance & duration');
       return;
     }
     const useTimer = useTimerEl.checked;
@@ -516,14 +524,15 @@ function openEditForm(item, idx){
           return;
         }
       } else if(currentExercise.isCardio){
-        const newD  = parseFloat(form.querySelector('.editD').value);
+        const rawD = parseFloat(form.querySelector('.editD').value);
+        const newD  = form.querySelector('.editD').value === '' ? null : rawD;
         const newDur = parseInt(form.querySelector('.editDur').value, 10);
         const vPlanned = form.querySelector('.editRestPlanned').value;
         const vActual  = form.querySelector('.editRestActual').value;
         const newPlanned = vPlanned === '' ? null : parseInt(vPlanned, 10);
         const newActual  = vActual  === '' ? null : parseInt(vActual, 10);
-        if(!canLogCardio(newD, newDur)){
-          alert('Enter valid distance & duration');
+        if(!canLogCardio(newD, newDur, currentExercise.name)){
+          alert(currentExercise.name === 'Jump Rope' ? 'Enter valid duration' : 'Enter valid distance & duration');
           return;
         }
         s.distance = newD;

--- a/tests/canLogSet.test.js
+++ b/tests/canLogSet.test.js
@@ -16,4 +16,7 @@ describe('canLogCardio', () => {
   it('rejects invalid duration', () => {
     expect(canLogCardio(1, 0)).toBe(false);
   });
+  it('allows missing distance for Jump Rope', () => {
+    expect(canLogCardio(null, 15, 'Jump Rope')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- permit Jump Rope exercises to log without distance
- handle optional cardio distance in logging and editing flows
- test Jump Rope without distance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893edb197c4833297179bd1de4d28af