### PR TITLE
Allow Jump Rope cardio without distance

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,8 @@
         </div>
         <div class="inline-row hidden" id="cardioInputs">
           <input type="number" id="distance" min="0" step="0.01" class="field" placeholder="Distance (mi)">
-          <input type="number" id="duration" min="1" step="1" class="field" placeholder="Duration (min)">
+          <input type="number" id="durationMin" min="0" step="1" class="field" placeholder="Min">
+          <input type="number" id="durationSec" min="0" max="59" step="1" class="field" placeholder="Sec">
         </div>
         <div id="supersetInputs" class="superset-inputs hidden"></div>
 

--- a/script.js
+++ b/script.js
@@ -541,9 +541,15 @@ function openEditForm(item, idx){
       } else if(currentExercise.isCardio){
         const rawD = parseFloat(form.querySelector('.editD').value);
         const newD  = form.querySelector('.editD').value === '' ? null : rawD;
-        const m = parseInt(form.querySelector('.editDurMin').value, 10) || 0;
-        const se = parseInt(form.querySelector('.editDurSec').value, 10) || 0;
-        const newDur = m * 60 + se;
+        const durField = form.querySelector('.editDur');
+        let newDur;
+        if (durField) {
+          newDur = parseInt(durField.value, 10);
+        } else {
+          const m = parseInt(form.querySelector('.editDurMin').value, 10) || 0;
+          const se = parseInt(form.querySelector('.editDurSec').value, 10) || 0;
+          newDur = m * 60 + se;
+        }
         const vPlanned = form.querySelector('.editRestPlanned').value;
         const vActual  = form.querySelector('.editRestActual').value;
         const newPlanned = vPlanned === '' ? null : parseInt(vPlanned, 10);

--- a/tests/canLogSet.test.js
+++ b/tests/canLogSet.test.js
@@ -11,9 +11,15 @@ describe('canLogSet', () => {
 
 describe('canLogCardio', () => {
   it('allows zero distance with positive duration', () => {
-    expect(canLogCardio(0, 30)).toBe(true);
+    expect(canLogCardio(0, 1800)).toBe(true); // 30 minutes
   });
   it('rejects invalid duration', () => {
     expect(canLogCardio(1, 0)).toBe(false);
+  });
+  it('allows missing distance for Jump Rope', () => {
+    expect(canLogCardio(null, 15, 'Jump Rope')).toBe(true); // 15 seconds
+  });
+  it('allows durations under a minute', () => {
+    expect(canLogCardio(0, 45)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- permit Jump Rope exercises to log without distance
- handle optional cardio distance in logging and editing flows
- hide distance field for Jump Rope to fix desktop usage
- allow entering cardio durations with minutes and seconds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893edb197c4833297179bd1de4d28af