### PR TITLE
Preserve duplicate sets when saving sessions to calendar

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -52,6 +52,25 @@ function parseCsv(text, selectedDate){
   return null;
 }
 
+// Convert a session snapshot into history lines with set numbers
+function snapshotToLines(snapshot){
+  const lines = [];
+  snapshot.forEach(ex => {
+    if(ex.isSuperset){
+      ex.sets.forEach((set, setIdx) => {
+        set.exercises.forEach(sub => {
+          lines.push(`${sub.name}: Set ${setIdx+1} - ${sub.weight} lbs × ${sub.reps} reps`);
+        });
+      });
+    } else {
+      ex.sets.forEach((set, setIdx) => {
+        lines.push(`${ex.name}: Set ${setIdx+1} - ${set.weight} lbs × ${set.reps} reps`);
+      });
+    }
+  });
+  return lines;
+}
+
 if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', () => {
     if(!document.getElementById('calendar')) return;
@@ -381,20 +400,7 @@ if (typeof document !== 'undefined') {
         alert('No session data to save');
         return;
       }
-      const lines = [];
-      snapshot.forEach(ex => {
-        if (ex.isSuperset) {
-          ex.sets.forEach(set => {
-            set.exercises.forEach(sub => {
-              lines.push(`${sub.name}: ${sub.weight} lbs × ${sub.reps} reps`);
-            });
-          });
-        } else {
-          ex.sets.forEach(set => {
-            lines.push(`${ex.name}: ${set.weight} lbs × ${set.reps} reps`);
-          });
-        }
-      });
+      const lines = snapshotToLines(snapshot);
       const res = mergeHistory({[selectedDate]: lines});
       save();
       renderDay();
@@ -412,5 +418,5 @@ if (typeof document !== 'undefined') {
   });
 }
 if (typeof module !== 'undefined') {
-  module.exports = { parseDateLocal, parseAiText, parseCsv };
+  module.exports = { parseDateLocal, parseAiText, parseCsv, snapshotToLines };
 }

--- a/tests/calendar.test.js
+++ b/tests/calendar.test.js
@@ -1,4 +1,4 @@
-const { parseDateLocal, parseAiText } = require('../calendar');
+const { parseDateLocal, parseAiText, snapshotToLines } = require('../calendar');
 
 test('parseDateLocal returns exact date', () => {
   const d = parseDateLocal('2025-08-01');
@@ -17,4 +17,23 @@ test('parseAiText parses exported AI text format', () => {
       'Squat: 225 lbs × 5 reps'
     ]
   });
+});
+
+test('snapshotToLines retains duplicate sets with numbering', () => {
+  const snapshot = [
+    {
+      name: 'Bench Press',
+      isSuperset: false,
+      isCardio: false,
+      sets: [
+        { weight: 185, reps: 5 },
+        { weight: 185, reps: 5 }
+      ]
+    }
+  ];
+  const lines = snapshotToLines(snapshot);
+  expect(lines).toEqual([
+    'Bench Press: Set 1 - 185 lbs × 5 reps',
+    'Bench Press: Set 2 - 185 lbs × 5 reps'
+  ]);
 });


### PR DESCRIPTION
## Summary
- Record set numbers when converting a session snapshot to calendar lines
- Use snapshotToLines in calendar saver so repeated sets aren't lost
- Test that snapshotToLines keeps duplicate sets with numbering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf8cc84f48332a7d965827410888e