### PR TITLE
Debounce exercise search to improve responsiveness

### DIFF
--- a/script.js
+++ b/script.js
@@ -67,6 +67,14 @@ const muscleFilter     = document.getElementById('muscleFilter');
 
 let allExercises = [];
 
+function debounce(fn, delay = 100){
+  let t;
+  return (...args) => {
+    clearTimeout(t);
+    t = setTimeout(() => fn(...args), delay);
+  };
+}
+
 async function loadExercises(){
   try {
     const res = await fetch('data/exercises.json');
@@ -137,7 +145,8 @@ function saveCustomExercises(){
   localStorage.setItem('custom_exercises', JSON.stringify(custom));
 }
 
-exerciseSearch.addEventListener('input', renderExerciseOptions);
+const renderExerciseOptionsDebounced = debounce(renderExerciseOptions, 150);
+exerciseSearch.addEventListener('input', renderExerciseOptionsDebounced);
 muscleFilter.addEventListener('change', renderExerciseOptions);
 exerciseSearch.addEventListener('change', () => {
   const val = exerciseSearch.value.trim();


### PR DESCRIPTION
## Summary
- Add a reusable `debounce` utility for controlling rapid-fire events
- Debounce exercise search input to avoid frequent DOM updates and speed up typing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf9f0a8a88332b042d27fcab693a9