### PR TITLE
Add progress charts with workout trend metrics

### DIFF
--- a/charts.html
+++ b/charts.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1.0" />
+<title>Workout Tracker — Progress Charts</title>
+<link rel="stylesheet" href="style.css">
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0;padding:16px;}
+header{display:flex;align-items:center;gap:8px;margin-bottom:16px;}
+header a{text-decoration:none;color:inherit;font-size:14px;}
+.controls{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:16px;align-items:flex-end;}
+.controls label{display:flex;flex-direction:column;font-size:14px;gap:4px;}
+#mainChart{max-width:100%;height:300px;}
+.small-charts{display:flex;flex-direction:column;gap:16px;margin-top:24px;}
+.small-charts canvas{flex:1;height:200px;}
+@media(min-width:700px){.small-charts{flex-direction:row;}}
+.sample-note{font-size:12px;opacity:0.7;margin-top:8px;}
+</style>
+</head>
+<body>
+<header>
+  <a href="index.html">&#8592; Back</a>
+  <h1>Progress Charts</h1>
+</header>
+<div id="sample-note" class="sample-note" style="display:none;">Showing sample data (no local data found).</div>
+<div class="controls">
+  <label>Lift
+    <select id="liftSelect">
+      <option value="bench">Bench Press</option>
+      <option value="squat">Squat</option>
+      <option value="incline">Incline</option>
+      <option value="deadlift">Deadlift</option>
+    </select>
+  </label>
+  <label>Metric
+    <select id="metricSelect">
+      <option value="e1rm">Estimated 1RM</option>
+      <option value="top">Top Set Weight</option>
+      <option value="volume">Daily Volume (lbs)</option>
+    </select>
+  </label>
+  <button id="refreshBtn" class="btn btn-secondary" style="height:32px;">Refresh</button>
+</div>
+<canvas id="mainChart"></canvas>
+<div class="small-charts">
+  <canvas id="benchChart"></canvas>
+  <canvas id="squatChart"></canvas>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+<script src="charts.js"></script>
+</body>
+</html>

--- a/charts.js
+++ b/charts.js
@@ -1,0 +1,127 @@
+// charts.js - renders progress charts from workout data
+
+const SAMPLE_DATA = [
+  { date: '2024-01-01', lift: 'bench', sets: [ { weight: 185, reps: 5 } ] },
+  { date: '2024-01-08', lift: 'bench', sets: [ { weight: 190, reps: 5 } ] },
+  { date: '2024-01-02', lift: 'squat', sets: [ { weight: 225, reps: 5 } ] },
+  { date: '2024-01-09', lift: 'squat', sets: [ { weight: 235, reps: 5 } ] },
+  { date: '2024-01-05', lift: 'bench', sets: [ { weight: 200, reps: 3 } ] },
+  { date: '2024-01-12', lift: 'squat', sets: [ { weight: 245, reps: 3 } ] },
+];
+
+function e1rm(weight, reps){
+  if(!isFinite(weight) || !isFinite(reps) || weight<=0 || reps<=0) return 0;
+  return Math.round(weight * (1 + reps/30));
+}
+
+async function loadWorkouts(){
+  let raw = null;
+  try{
+    const ls = localStorage.getItem('workouts') || localStorage.getItem('wt_history');
+    if(ls) raw = JSON.parse(ls);
+  }catch{}
+  if(!raw){
+    try{
+      const res = await fetch('data/workouts.json', {cache:'no-store'});
+      if(res.ok) raw = await res.json();
+    }catch{}
+  }
+  if(!raw){
+    raw = SAMPLE_DATA;
+    const note = document.getElementById('sample-note');
+    if(note) note.style.display='block';
+  }
+  return normalizeWorkouts(raw);
+}
+
+function normalizeWorkouts(raw){
+  // If array already
+  if(Array.isArray(raw)){
+    return raw.map(r=>({
+      date: r.date,
+      lift: canonicalLift(r.lift),
+      sets: r.sets ? r.sets.map(s=>({weight:+s.weight,reps:+s.reps})) : []
+    }));
+  }
+  // assume object keyed by date -> ["Bench Press: 100 lbs × 5 reps"]
+  const workouts = [];
+  for(const [date, entries] of Object.entries(raw||{})){
+    const lifts = {};
+    entries.forEach(line=>{
+      const m = line.match(/^(.*?):\s*(\d+)\s*lbs\s*×\s*(\d+)\s*reps?/i);
+      if(!m) return;
+      let [, name, w, r] = m;
+      const lift = canonicalLift(name);
+      if(!lifts[lift]) lifts[lift] = { date, lift, sets: [] };
+      lifts[lift].sets.push({ weight:+w, reps:+r });
+    });
+    workouts.push(...Object.values(lifts));
+  }
+  return workouts;
+}
+
+function canonicalLift(name){
+  const n = (name||'').toLowerCase();
+  if(n.includes('bench')) return 'bench';
+  if(n.includes('squat')) return 'squat';
+  if(n.includes('incline')) return 'incline';
+  if(n.includes('dead')) return 'deadlift';
+  return n;
+}
+
+function computeDaily(workouts, lift, metric){
+  const daily = {};
+  const target = lift.toLowerCase();
+  workouts.filter(w => canonicalLift(w.lift) === target).forEach(w=>{
+    const day = w.date;
+    if(!daily[day]) daily[day] = { e1rmMax:0, topSet:0, volume:0 };
+    w.sets.forEach(set=>{
+      const e = e1rm(set.weight, set.reps);
+      if(e > daily[day].e1rmMax) daily[day].e1rmMax = e;
+      if(set.weight > daily[day].topSet) daily[day].topSet = set.weight;
+      daily[day].volume += set.weight * set.reps;
+    });
+  });
+  const key = metric==='e1rm'? 'e1rmMax' : metric==='top'? 'topSet' : 'volume';
+  return Object.entries(daily).map(([d,v])=>({ x: new Date(d), y: v[key] })).sort((a,b)=>a.x-b.x);
+}
+
+function makeLineChart(ctx, label, dataPoints){
+  return new Chart(ctx, {
+    type: 'line',
+    data: { datasets:[{ label, data:dataPoints, tension:0.25, pointRadius:3 }] },
+    options:{
+      parsing:false,
+      interaction:{mode:'index',intersect:false},
+      scales:{x:{type:'time',time:{unit:'day'}}}
+    }
+  });
+}
+
+async function init(){
+  const workouts = await loadWorkouts();
+  const liftSelect = document.getElementById('liftSelect');
+  const metricSelect = document.getElementById('metricSelect');
+  const refreshBtn = document.getElementById('refreshBtn');
+  const mainCtx = document.getElementById('mainChart').getContext('2d');
+  const benchCtx = document.getElementById('benchChart').getContext('2d');
+  const squatCtx = document.getElementById('squatChart').getContext('2d');
+  let mainChart = null;
+  function renderMain(){
+    const data = computeDaily(workouts, liftSelect.value, metricSelect.value);
+    if(mainChart) mainChart.destroy();
+    mainChart = makeLineChart(mainCtx, `${liftSelect.value} - ${metricSelect.options[metricSelect.selectedIndex].text}`, data);
+  }
+  refreshBtn.addEventListener('click', renderMain);
+  renderMain();
+  makeLineChart(benchCtx, 'Bench - E1RM', computeDaily(workouts, 'bench', 'e1rm'));
+  makeLineChart(squatCtx, 'Squat - E1RM', computeDaily(workouts, 'squat', 'e1rm'));
+}
+
+if(typeof window !== 'undefined'){
+  window.addEventListener('DOMContentLoaded', init);
+}
+
+if(typeof module !== 'undefined'){
+  module.exports = { e1rm, computeDaily, normalizeWorkouts };
+}

--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
       <div id="today" class="date"></div>
     </div>
 
+    <div style="margin:8px 0;">
+      <a href="charts.html" class="btn btn-secondary">View Progress Charts</a>
+    </div>
+
     <div class="section">
 
       <!-- Add Custom Exercise -->

--- a/tests/charts.metrics.test.js
+++ b/tests/charts.metrics.test.js
@@ -1,0 +1,26 @@
+const { e1rm, computeDaily } = require('../charts.js');
+
+describe('e1rm', () => {
+  test('calculates Estimated 1RM', () => {
+    expect(e1rm(255, 2)).toBe(Math.round(255 * (1 + 2/30)));
+    expect(e1rm(100, 10)).toBe(Math.round(100 * (1 + 10/30)));
+  });
+  test('returns 0 for invalid input', () => {
+    expect(e1rm(-1, 5)).toBe(0);
+    expect(e1rm(100, 0)).toBe(0);
+  });
+});
+
+describe('computeDaily', () => {
+  const mock = [
+    { date: '2024-01-01', lift: 'bench', sets: [{ weight: 100, reps: 5 }] },
+    { date: '2024-01-01', lift: 'bench', sets: [{ weight: 110, reps: 3 }] },
+    { date: '2024-01-02', lift: 'bench', sets: [{ weight: 120, reps: 2 }] },
+  ];
+  test('aggregates volume by day', () => {
+    const res = computeDaily(mock, 'bench', 'volume');
+    expect(res.length).toBe(2);
+    const day1 = res.find(r => r.x.getTime() === new Date('2024-01-01').getTime());
+    expect(day1.y).toBe(100*5 + 110*3);
+  });
+});


### PR DESCRIPTION
## Summary
- add `charts.html` and `charts.js` for interactive progress charts using Chart.js
- support data from localStorage (`workouts` or existing `wt_history`), `data/workouts.json`, or bundled sample data
- compute E1RM, top set weight, and daily volume with helper functions and unit tests
- link from homepage to new charts page

## Testing
- `npm test`

## Screenshots
- Desktop: TODO
- Mobile: TODO

------
https://chatgpt.com/codex/tasks/task_e_68acfbd37ce483328fc24453466006c2