### PR TITLE
Add robust chart data fallback and empty state handling

### DIFF
--- a/charts.html
+++ b/charts.html
@@ -43,6 +43,7 @@ header a{text-decoration:none;color:inherit;font-size:14px;}
   <button id="refreshBtn" class="btn btn-secondary" style="height:32px;">Refresh</button>
 </div>
 <canvas id="mainChart"></canvas>
+<div id="empty-message" style="display:none;text-align:center;margin-top:16px;">No data for this lift.</div>
 <div class="small-charts">
   <canvas id="benchChart"></canvas>
   <canvas id="squatChart"></canvas>


### PR DESCRIPTION
## Summary
- load workout data from multiple localStorage keys or sample data as fallback
- normalize workout formats and canonicalize lift names
- show a helpful message when no chart data exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad0f0a638c8332b032d9ece0a8d8c3