### PR TITLE
Fix workout saving and load in-progress data for charts

### DIFF
--- a/script.js
+++ b/script.js
@@ -841,7 +841,8 @@ if (typeof document !== "undefined" && document.getElementById("today")) {
     const hasData =
       session.exercises.length ||
       (currentExercise && currentExercise.sets.length);
-    if (hasData && confirm("Save today's session lines to calendar?")) {
+    if (hasData) {
+      // Automatically persist session summary so charts can use it
       saveSessionLinesToHistory();
     }
   }


### PR DESCRIPTION
## Summary
- Automatically persist workout lines to history when ending a session
- Use active session data (`wt_session` / `wt_currentExercise`) if no saved workouts for charts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad21d58ef08332b4b19d2bcbab9d69