### PR TITLE
feat: add manual input for progress charts

### DIFF
--- a/charts.html
+++ b/charts.html
@@ -22,6 +22,8 @@
   @media(min-width:700px){.small-charts{flex-direction:row;}}
   .sample-note{font-size:12px;opacity:0.7;margin-top:8px;}
   .message{font-size:14px;opacity:0.8;text-align:center;margin:10px 0;}
+  .manual-import textarea{width:100%;height:80px;}
+  .manual-import{margin-bottom:12px;}
 </style>
 </head>
 <body>
@@ -31,6 +33,11 @@
 </header>
 
 <div id="sample-note" class="sample-note" style="display:none;">Showing sample data (no local data found).</div>
+
+<div class="manual-import">
+  <textarea id="manualData" placeholder="Paste exported workout JSON here"></textarea>
+  <button id="loadManualBtn" class="btn btn-secondary" style="margin-top:8px;">Load Data</button>
+</div>
 
 <div class="controls">
   <label>Lift


### PR DESCRIPTION
## Summary
- allow users to paste exported workout JSON and load it into progress charts
- save pasted data to localStorage for reuse and refresh charts accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad2bf65f188332b3b4e20a79daca59