### PR TITLE
feat: add chart export and refine charts UI

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -97,7 +97,7 @@ if (typeof document !== 'undefined') {
     const calGo = document.getElementById('calGo');
     const pasteJson = document.getElementById('pasteJson');
     const importFromPaste = document.getElementById('importFromPaste');
-    const clearDayBtn = document.getElementById('clearDay');
+      const resetDayBtn = document.getElementById('resetDay');
 
     function updateDateInput(){
       calGoto.value = selectedDate;
@@ -233,8 +233,8 @@ if (typeof document !== 'undefined') {
         li.appendChild(actions);
         entriesEl.appendChild(li);
       });
-      if(clearDayBtn){
-        clearDayBtn.disabled = list.length === 0;
+      if(resetDayBtn){
+        resetDayBtn.disabled = list.length === 0;
       }
       updateDateInput();
     }
@@ -249,9 +249,8 @@ if (typeof document !== 'undefined') {
       renderCalendar();
     });
 
-    if(clearDayBtn){
-      clearDayBtn.addEventListener('click', () => {
-        if(!history[selectedDate] || !history[selectedDate].length) return;
+    if(resetDayBtn){
+      resetDayBtn.addEventListener('click', () => {
         if(confirm('Clear all entries for this day?')){
           delete history[selectedDate];
           save();

--- a/charts.html
+++ b/charts.html
@@ -1,71 +1,62 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width,initial-scale=1.0" />
-<title>Workout Tracker — Progress Charts</title>
-<link rel="stylesheet" href="style.css">
-<style>
-  body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0;padding:16px;}
-  header{display:flex;align-items:center;gap:8px;margin-bottom:16px;}
-  header a{text-decoration:none;color:inherit;font-size:14px;}
-  .controls{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:12px;align-items:flex-end;}
-  .controls label{display:flex;flex-direction:column;font-size:14px;gap:4px;}
-  #refreshBtn,#seedBtn{
-    height:40px; width:100%;
-    position:relative; z-index:10; /* keep buttons clickable above anything */
-    cursor:pointer;
-  }
-  #mainChart{max-width:100%;height:300px;}
-  .small-charts{display:flex;flex-direction:column;gap:16px;margin-top:16px;}
-  .small-charts canvas{flex:1;height:200px;}
-  @media(min-width:700px){.small-charts{flex-direction:row;}}
-  .sample-note{font-size:12px;opacity:0.7;margin-top:8px;}
-  .message{font-size:14px;opacity:0.8;text-align:center;margin:10px 0;}
-</style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+  <title>Workout Tracker — Progress Charts</title>
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-<header>
-  <a href="index.html">&#8592; Back</a>
-  <h1>Progress Charts</h1>
-</header>
+  <div class="container">
+    <div class="header">
+      <h1>Progress Charts</h1>
+    </div>
+    <div class="section charts-section">
+      <a href="index.html" class="btn btn-secondary" style="margin-bottom:12px;">← Back</a>
 
-<div id="sample-note" class="sample-note" style="display:none;">Showing sample data (no local data found).</div>
+      <div id="sample-note" class="sample-note" style="display:none;">Showing sample data (no local data found).</div>
 
-<div class="controls">
-  <label>Lift
-    <select id="liftSelect">
-      <option value="bench">Bench Press</option>
-      <option value="squat">Squat</option>
-      <option value="incline">Incline</option>
-      <option value="deadlift">Deadlift</option>
-    </select>
-  </label>
-  <label>Metric
-    <select id="metricSelect">
-      <option value="e1rm">Estimated 1RM</option>
-      <option value="top">Top Set Weight</option>
-      <option value="volume">Daily Volume (lbs)</option>
-    </select>
-  </label>
-</div>
+      <div class="manual-import">
+        <textarea id="manualData" class="field" placeholder="Paste exported workout JSON here"></textarea>
+        <button id="loadManualBtn" class="btn btn-secondary">Load Data</button>
+      </div>
 
-<button id="refreshBtn" class="btn btn-secondary">Refresh</button>
-<button id="seedBtn" class="btn btn-secondary">Seed Sample</button>
+      <div class="controls">
+        <label>Lift
+          <select id="liftSelect" class="field">
+            <option value="bench">Bench Press</option>
+            <option value="squat">Squat</option>
+            <option value="incline">Incline</option>
+            <option value="deadlift">Deadlift</option>
+          </select>
+        </label>
+        <label>Metric
+          <select id="metricSelect" class="field">
+            <option value="e1rm">Estimated 1RM</option>
+            <option value="top">Top Set Weight</option>
+            <option value="volume">Daily Volume (lbs)</option>
+          </select>
+        </label>
+      </div>
 
-<div id="empty-message" class="message" style="display:none;">No data for this lift.</div>
+      <button id="refreshBtn" class="btn btn-secondary">Refresh</button>
+      <button id="seedBtn" class="btn btn-secondary">Seed Sample</button>
 
-<canvas id="mainChart"></canvas>
+      <div id="empty-message" class="message" style="display:none;">No data for this lift.</div>
 
-<small class="sample-note">E1RM = estimated 1-rep max (Epley); Top Set = heaviest set; Volume = total lbs (weight × reps) per day.</small>
+      <canvas id="mainChart"></canvas>
 
-<div class="small-charts">
-  <canvas id="benchChart"></canvas>
-  <canvas id="squatChart"></canvas>
-</div>
+      <small class="sample-note">E1RM = estimated 1-rep max (Epley); Top Set = heaviest set; Volume = total lbs (weight × reps) per day.</small>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
-<script src="charts.js"></script>
+      <div class="small-charts">
+        <canvas id="benchChart"></canvas>
+        <canvas id="squatChart"></canvas>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+  <script src="charts.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
             <input type="text" id="entryInput" class="field" placeholder="Add workout note">
             <button id="addEntry" class="btn btn-secondary" style="flex:0 0 80px;">Add</button>
           </div>
-          <button id="clearDay" class="btn btn-reset" style="margin-top:8px;">Clear Day</button>
+          <button id="resetDay" class="btn btn-reset" style="margin-top:8px;">Reset Day</button>
         </div>
         <div class="history-actions">
           <button id="saveTodaySession" class="btn btn-secondary">Save Today from Session</button>
@@ -130,6 +130,7 @@
       </div>
 
       <button id="exportBtn" class="btn btn-export">Export (JSON + AI + CSV)</button>
+      <button id="exportChartData" class="btn btn-secondary">Export for Charts</button>
 
     </div>
   </div>

--- a/script.js
+++ b/script.js
@@ -48,6 +48,7 @@ if (typeof document !== "undefined" && document.getElementById("today")) {
   const finishBtn = document.getElementById("finishBtn");
   const resetBtn = document.getElementById("resetBtn");
   const exportBtn = document.getElementById("exportBtn");
+  const exportChartBtn = document.getElementById("exportChartData");
   const restBox = document.getElementById("restBox");
   const restDisplay = document.getElementById("restDisplay");
   const useTimerEl = document.getElementById("useTimer");
@@ -1070,6 +1071,33 @@ if (typeof document !== "undefined" && document.getElementById("today")) {
       alert("Exported JSON + CSV. Copy this manually:\n\n" + aiText);
     }
   });
+
+  /* ------------------ EXPORT FOR CHARTS ------------------ */
+  if (exportChartBtn) {
+    exportChartBtn.addEventListener("click", () => {
+      saveSessionLinesToHistory();
+      const history = JSON.parse(localStorage.getItem("wt_history") || "{}");
+      if (!Object.keys(history).length) {
+        alert("No data to export.");
+        return;
+      }
+      const data = JSON.stringify(history, null, 2);
+      triggerDownload(
+        new Blob([data], { type: "application/json" }),
+        "chart_data.json",
+      );
+      if (navigator.clipboard) {
+        navigator.clipboard
+          .writeText(data)
+          .then(() => {
+            alert("Chart data exported and copied to clipboard ✅");
+          })
+          .catch(() => alert("Chart data exported (clipboard copy failed)"));
+      } else {
+        alert("Chart data exported. Copy manually:\n\n" + data);
+      }
+    });
+  }
   function triggerDownload(blob, filename) {
     const link = document.createElement("a");
     link.href = URL.createObjectURL(blob);

--- a/style.css
+++ b/style.css
@@ -210,3 +210,16 @@ body.dark #calendarSection{
 .calendar-controls .btn{width:auto;}
 #pasteImport{margin-top:8px;}
 #pasteImport textarea{width:100%;min-height:80px;}
+
+/* charts page */
+.charts-section .controls{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:12px;align-items:flex-end;}
+.charts-section .controls label{display:flex;flex-direction:column;font-size:14px;gap:4px;flex:1;}
+.charts-section #mainChart{max-width:100%;height:300px;}
+.charts-section .small-charts{display:flex;flex-direction:column;gap:16px;margin-top:16px;}
+@media(min-width:700px){.charts-section .small-charts{flex-direction:row;}}
+.charts-section .small-charts canvas{flex:1;height:200px;}
+.charts-section .manual-import textarea{height:80px;}
+.charts-section .manual-import{margin-bottom:12px;}
+.charts-section #refreshBtn,.charts-section #seedBtn{position:relative;z-index:10;}
+.charts-section .message{font-size:14px;opacity:.8;text-align:center;margin:10px 0;}
+.charts-section .sample-note{font-size:12px;opacity:.7;margin-top:8px;}


### PR DESCRIPTION
## Summary
- add Export for Charts button that saves chart-friendly JSON and copies it to the clipboard
- fix Reset Day control and align charts page styling with the rest of the app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad2bf65f188332b3b4e20a79daca59