### PR TITLE
Fix add entry button in progress charts

### DIFF
--- a/charts.html
+++ b/charts.html
@@ -18,7 +18,7 @@
 
       <div class="manual-import">
         <textarea id="manualData" class="field" placeholder="Paste exported workout JSON here"></textarea>
-        <button id="loadManualBtn" class="btn btn-secondary">Load Data</button>
+        <button id="loadManualBtn" class="btn btn-secondary" type="button">Load Data</button>
       </div>
 
       <div class="manual-entry">
@@ -36,7 +36,7 @@
           <input type="number" id="entryWeight" class="field" placeholder="Weight (lbs)" min="0" step="1">
           <input type="number" id="entryReps" class="field" placeholder="Reps" min="1" step="1">
         </div>
-        <button id="addEntryBtn" class="btn btn-primary" style="margin-top:4px;">Add Entry</button>
+        <button id="addEntryBtn" class="btn btn-primary" type="button" style="margin-top:4px;">Add Entry</button>
       </div>
 
       <div class="controls">

--- a/charts.js
+++ b/charts.js
@@ -248,7 +248,8 @@ async function init(){
 
   if(entryDate) entryDate.value = toDayISO(new Date());
   if(addEntryBtn){
-    addEntryBtn.addEventListener('click',()=>{
+    addEntryBtn.addEventListener('click', async (e)=>{
+      e.preventDefault();
       const date = entryDate?.value || toDayISO(new Date());
       const lift = entryLift?.value || '';
       const weight = Number(entryWeight?.value);
@@ -263,7 +264,7 @@ async function init(){
       localStorage.setItem('manual_entries', JSON.stringify(entries));
       if(entryWeight) entryWeight.value = '';
       if(entryReps) entryReps.value = '';
-      refresh();
+      await refresh();
     });
   }
 


### PR DESCRIPTION
## Summary
- prevent manual data buttons from submitting forms
- await chart refresh after adding manual entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adcab65b048332bd0951eae13a0693