### PR TITLE
Fix add entry button in progress charts

### DIFF
--- a/charts.html
+++ b/charts.html
@@ -18,7 +18,7 @@
 
       <div class="manual-import">
         <textarea id="manualData" class="field" placeholder="Paste exported workout JSON here"></textarea>
-        <button id="loadManualBtn" class="btn btn-secondary">Load Data</button>
+        <button id="loadManualBtn" class="btn btn-secondary" type="button">Load Data</button>
       </div>
 
       <div class="manual-entry">
@@ -36,7 +36,7 @@
           <input type="number" id="entryWeight" class="field" placeholder="Weight (lbs)" min="0" step="1">
           <input type="number" id="entryReps" class="field" placeholder="Reps" min="1" step="1">
         </div>
-        <button id="addEntryBtn" class="btn btn-primary" style="margin-top:4px;">Add Entry</button>
+        <button id="addEntryBtn" class="btn btn-primary" type="button" style="margin-top:4px;">Add Entry</button>
       </div>
 
       <div class="controls">
@@ -73,8 +73,8 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.umd.min.js"></script>
   <script src="charts.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- prevent manual data buttons from submitting forms
- await chart refresh after adding manual entry
- ensure Chart.js and date adapter load via UMD builds
- centralize JSON parsing and warn when fetch fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adcab65b048332bd0951eae13a0693