### PR TITLE
feat(data): robust export/import with schema v2

### DIFF
--- a/tests/canLogSet.test.js
+++ b/tests/canLogSet.test.js
@@ -1,4 +1,4 @@
-const { canLogSet, canLogCardio } = require('../script');
+const { canLogSet, canLogCardio, normalizeSet, normalizePayload } = require('../script');
 
 describe('canLogSet', () => {
   it('allows zero weight with positive reps', () => {
@@ -27,5 +27,24 @@ describe('canLogCardio', () => {
   });
   it('rejects negative distance', () => {
     expect(canLogCardio(-1, 60, 'Run')).toBe(false);
+  });
+});
+
+describe('data normalization', () => {
+  it('sanitizes set values', () => {
+    const set = normalizeSet({ weight: -5, reps: -2, duration: -10, restActual: 'NaN' });
+    expect(set.weight).toBe(0);
+    expect(set.reps).toBe(1);
+    expect(set.duration).toBe(0);
+    expect(set.restActual).toBeNull();
+  });
+
+  it('normalizes payload arrays', () => {
+    const norm = normalizePayload([{ name: 'Bench', sets: [{ weight: '20', reps: '-3' }] }]);
+    expect(norm.totalExercises).toBe(1);
+    expect(norm.totalSets).toBe(1);
+    expect(norm.exercises[0].sets[0].weight).toBe(20);
+    expect(norm.exercises[0].sets[0].reps).toBe(1);
+    expect(norm.schema).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- add schema v2 and comprehensive normalization utilities for sets, exercises, and payloads
- inject file and paste JSON import UI with history merge and undo
- export JSON now tagged with schema and supports safe undoable imports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1fcddd788332a93518ac6f9b76d5