### PR TITLE
feat(find): fast find search + quick filters with recent picks

### DIFF
--- a/tests/fastFindFilter.test.js
+++ b/tests/fastFindFilter.test.js
@@ -1,0 +1,26 @@
+const { ffMatchesFilter } = require('../script');
+
+describe('fast find filter predicates', () => {
+  const strengthEx = { name: 'Bench Press', category: 'Chest' };
+  const cardioEx = { name: 'Run', category: 'Cardio', isCardio: true };
+  const customEx = { name: 'My Move', category: 'Arms', custom: true };
+  const supersetEx = { name: 'Bench + Row', isSuperset: true };
+
+  it('strength filter includes only strength exercises', () => {
+    expect(ffMatchesFilter(strengthEx, 'strength')).toBe(true);
+    expect(ffMatchesFilter(cardioEx, 'strength')).toBe(false);
+    expect(ffMatchesFilter(supersetEx, 'strength')).toBe(false);
+  });
+
+  it('cardio filter matches cardio and special cases', () => {
+    expect(ffMatchesFilter(cardioEx, 'cardio')).toBe(true);
+    expect(ffMatchesFilter({ name: 'Plank', category: 'Core' }, 'cardio')).toBe(true);
+    expect(ffMatchesFilter(strengthEx, 'cardio')).toBe(false);
+  });
+
+  it('custom filter includes only custom exercises', () => {
+    expect(ffMatchesFilter(customEx, 'custom')).toBe(true);
+    expect(ffMatchesFilter(strengthEx, 'custom')).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- inject Fast Find search bar with chip filters and responsive styling via script
- filter exercises by query, category chips, and show recent selections
- track last 5 exercises and add unit tests for filter predicates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae2235d430833283a58c636dd12e79