### PR TITLE
feat(calendar): fast history scanning with collapsible day cards, inline edit/quick add/delete, daily totals, lazy rendering, and undo; a11y announcements and scoped styles; no HTML changes

### DIFF
--- a/tests/calendar.parse.test.js
+++ b/tests/calendar.parse.test.js
@@ -1,0 +1,21 @@
+const { parseHistoryLine, computeDayTotals } = require('../calendar');
+
+describe('parseHistoryLine', () => {
+  test('parses valid line', () => {
+    expect(parseHistoryLine('Bench Press: 185 lbs × 5 reps')).toEqual({ name: 'Bench Press', weight: 185, reps: 5 });
+  });
+  test('returns null for invalid line', () => {
+    expect(parseHistoryLine('not valid')).toBeNull();
+  });
+});
+
+describe('computeDayTotals', () => {
+  test('computes sets and volume ignoring invalid lines', () => {
+    const lines = [
+      'Bench Press: 100 lbs × 5 reps',
+      'oops',
+      'Squat: 200 lbs × 3 reps'
+    ];
+    expect(computeDayTotals(lines)).toEqual({ sets: 2, volume: 100*5 + 200*3 });
+  });
+});


### PR DESCRIPTION
## Summary
- inject lightweight calendar UI from JS only, mounting automatically and scoping styles
- show last 90 days with collapsible cards, daily totals, inline edit/add/delete, undo, and keyboard/a11y support
- add parser helpers and tests for line parsing and total calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae25ee72d08332adce1fd555e803a0