### PR TITLE
feat(logging): smart defaults, quick-adjust controls, and repeat-last for faster mobile logging

### DIFF
--- a/style.css
+++ b/style.css
@@ -272,3 +272,22 @@ body.dark #calendarSection{
   .calendar-controls #calGoto,.calendar-controls .btn{width:100%;}
 }
 
+/* Quick adjust controls */
+.wt-adjust { display:flex; gap:6px; flex-wrap:wrap; margin-top:6px; }
+.wt-adjust .btn-mini {
+  padding: 6px 10px; border-radius: 10px; border: 1px solid var(--hairline, #ddd);
+  background: var(--panel, #f6f6f6); font-size: 13px; line-height: 1; cursor: pointer;
+}
+.wt-adjust .btn-mini:active { transform: scale(0.98); }
+@media (prefers-color-scheme: dark) {
+  .wt-adjust .btn-mini { background:#1b1b1b; border-color:#333; color:#ddd; }
+}
+/* Repeat last */
+#repeatLastBtn {
+  margin-left: 8px; padding: 8px 12px; border-radius:10px; border:1px solid var(--hairline, #ddd);
+  background: transparent; font-size: 14px; cursor: pointer;
+}
+@media (prefers-color-scheme: dark) {
+  #repeatLastBtn { border-color:#333; color:#ddd; }
+}
+

--- a/tests/defaults.test.js
+++ b/tests/defaults.test.js
@@ -1,0 +1,35 @@
+const { getLastSetForExercise, computeNextDefaults } = require('../script.js');
+
+describe('getLastSetForExercise', () => {
+  test('returns last set from current exercise first', () => {
+    const cur = { name: 'Bench', isCardio: false, isSuperset: false, sets: [
+      { weight: 100, reps: 8 },
+      { weight: 105, reps: 5 }
+    ]};
+    const sess = { exercises: [{ name: 'Bench', isCardio: false, isSuperset: false, sets: [{ weight: 95, reps: 5 }] }] };
+    expect(getLastSetForExercise('Bench', cur, sess)).toEqual({ weight: 105, reps: 5 });
+  });
+
+  test('scans session exercises from newest back', () => {
+    const cur = { name: 'Squat', isCardio: false, isSuperset: false, sets: [] };
+    const sess = {
+      exercises: [
+        { name: 'Bench', isCardio: false, isSuperset: false, sets: [{ weight: 90, reps: 5 }] },
+        { name: 'Bench', isCardio: false, isSuperset: false, sets: [{ weight: 110, reps: 5 }] }
+      ]
+    };
+    expect(getLastSetForExercise('Bench', cur, sess)).toEqual({ weight: 110, reps: 5 });
+  });
+});
+
+describe('computeNextDefaults', () => {
+  test('returns blanks when no last set', () => {
+    expect(computeNextDefaults(null)).toEqual({ weight: '', reps: '' });
+  });
+  test('suggests same weight and reps 8 when reps >= 8', () => {
+    expect(computeNextDefaults({ weight: 185, reps: 10 })).toEqual({ weight: 185, reps: 8 });
+  });
+  test('increases weight by 2.5% and rounds to 5 when reps < 8', () => {
+    expect(computeNextDefaults({ weight: 100, reps: 5 })).toEqual({ weight: 105, reps: 5 });
+  });
+});


### PR DESCRIPTION
## Summary
- suggest weight/reps based on last set and auto-fill when starting or logging
- inject mini weight/reps adjusters with hold-to-repeat and haptics
- add repeat-last-set button and long-press Log Set to repeat and log instantly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae2c5004008332933ed337108d2236