### PR TITLE
Fix mobile zoom when focusing search bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width,initial-scale=1.0" />
+<meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no" />
 <title>Workout Tracker Pro</title>
 <meta name="description" content="Lightweight mobile workout tracker with export + AI summary">
 <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
## Summary
- prevent mobile zoom when focusing inputs by disallowing page scaling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae3392878c8332a46782cff7266b25