### PR TITLE
feat(calendar): restore reliable month grid with day cards, stats, a11y, and edit/delete wired to history; mobile/dark friendly

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -1,349 +1,321 @@
 /**
- * Lightweight calendar/history renderer injected without HTML changes.
- * Provides collapsible day cards with inline editing, quick add,
- * delete and undo. Everything is mounted dynamically.
+ * Calendar utilities and month view renderer.
+ * This module exposes helpers for parsing workout history lines
+ * and mounts a simple month calendar that reads from localStorage.
  */
 
 const LINE_RE = /^(.*?):\s*(\d+(?:\.\d+)?)\s*lbs\s*[×x]\s*(\d+)\s*reps\s*$/i;
-function parseHistoryLine(str){
-  const m = String(str||'').match(LINE_RE);
-  if(!m) return null;
+
+function parseHistoryLine(str) {
+  const m = String(str || '').match(LINE_RE);
+  if (!m) return null;
   return { name: m[1].trim(), weight: +m[2], reps: +m[3] };
 }
 
-function parseDateLocal(str){
-  const [y,m,d] = String(str).split('-').map(Number);
-  return new Date(y, m-1, d);
+function computeDayTotals(lines) {
+  let sets = 0, volume = 0;
+  (Array.isArray(lines) ? lines : []).forEach(l => {
+    const p = parseHistoryLine(l);
+    if (p) { sets++; volume += p.weight * p.reps; }
+  });
+  return { sets, volume };
 }
 
-function parseAiText(text, selectedDate){
-  const lines = String(text||'').split(/\r?\n/);
+function parseDateLocal(str) {
+  const [y, m, d] = String(str).split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function parseAiText(text, selectedDate) {
+  const lines = String(text || '').split(/\r?\n/);
   let target = selectedDate;
   const header = lines[0] && lines[0].match(/WORKOUT DATA - (\d{4}-\d{2}-\d{2})/i);
-  if(header) target = header[1];
+  if (header) target = header[1];
   const out = [];
   let currentExercise = null;
   lines.forEach(l => {
     const trimmed = l.trim();
-    if(!trimmed) return;
+    if (!trimmed) return;
     const exHeader = trimmed.match(/^([^:]+):\s*$/);
-    if(exHeader){
+    if (exHeader) {
       currentExercise = exHeader[1].trim();
       return;
     }
     const setMatch = trimmed.match(/^(?:Set\s+\d+\s*[-–:]?\s*)?(.*?):\s*(\d+(?:\.\d+)?)\s*(?:lbs|kg)\s*[×xX]\s*(\d+)\s*reps/i);
-    if(setMatch){
+    if (setMatch) {
       let name = setMatch[1].trim();
-      if(!name && currentExercise) name = currentExercise;
-      if(name){
+      if (!name && currentExercise) name = currentExercise;
+      if (name) {
         out.push(`${name}: ${setMatch[2]} lbs × ${setMatch[3]} reps`);
       }
     }
   });
-  if(out.length){
-    return {[target]: out};
-  }
+  if (out.length) return { [target]: out };
   return null;
 }
 
-function snapshotToLines(snapshot){
+function snapshotToLines(snapshot) {
   const lines = [];
-  (snapshot||[]).forEach(ex => {
-    if(ex.isSuperset){
+  (snapshot || []).forEach(ex => {
+    if (ex.isSuperset) {
       ex.sets.forEach((set, setIdx) => {
-        (set.exercises||[]).forEach(sub => {
-          lines.push(`${sub.name}: Set ${setIdx+1} - ${sub.weight} lbs × ${sub.reps} reps`);
+        (set.exercises || []).forEach(sub => {
+          lines.push(`${sub.name}: Set ${setIdx + 1} - ${sub.weight} lbs × ${sub.reps} reps`);
         });
       });
     } else {
-      (ex.sets||[]).forEach((set, setIdx) => {
-        lines.push(`${ex.name}: Set ${setIdx+1} - ${set.weight} lbs × ${set.reps} reps`);
+      (ex.sets || []).forEach((set, setIdx) => {
+        lines.push(`${ex.name}: Set ${setIdx + 1} - ${set.weight} lbs × ${set.reps} reps`);
       });
     }
   });
   return lines;
 }
-function computeDayTotals(lines){
-  let sets=0, volume=0;
-  (Array.isArray(lines)?lines:[]).forEach(l=>{
-    const p=parseHistoryLine(l);
-    if(p){ sets++; volume += p.weight*p.reps; }
+
+// --- new calendar helpers ---
+
+function parseHistoryLines(lines) {
+  const out = { sets: 0, volume: 0, entries: [] };
+  (Array.isArray(lines) ? lines : []).forEach(text => {
+    const p = parseHistoryLine(text);
+    if (p) {
+      out.sets++;
+      out.volume += p.weight * p.reps;
+      out.entries.push({ text, lift: p.name, weight: p.weight, reps: p.reps });
+    }
   });
-  return { sets, volume };
+  return out;
 }
 
-if (typeof document !== 'undefined') {
-  document.addEventListener('DOMContentLoaded', () => {
-    // mount
-    let mount = document.getElementById('calendar') || document.getElementById('calendarRoot') || document.querySelector('section[data-role="calendar"]');
-    if(!mount){
-      mount = document.createElement('section');
-      mount.id = 'calendar';
-      const h1 = document.querySelector('h1');
-      if(h1 && h1.parentNode){ h1.insertAdjacentElement('afterend', mount); }
-      else document.body.insertBefore(mount, document.body.firstChild);
-    }
-    mount.classList.add('wt-cal');
+const HISTORY_KEY = 'wt_history';
 
-    // style
-    const style = document.createElement('style');
-    style.textContent = `
-.wt-cal{font-family:sans-serif;}
-.wt-cal .wt-cal-controls{display:flex;gap:8px;margin-bottom:8px;}
-.wt-cal-day{border:1px solid #ccc;border-radius:6px;margin-bottom:8px;}
-.wt-cal-day-header{width:100%;background:none;border:0;padding:8px;display:flex;flex-wrap:wrap;justify-content:space-between;align-items:center;text-align:left;font-size:1rem;}
-.wt-cal-day-header:focus{outline:2px solid #09f;}
-.wt-cal-chevron{transition:transform .2s ease;}
-.wt-cal-day-header[aria-expanded="false"] .wt-cal-chevron{transform:rotate(-90deg);}
-.wt-cal-day-body{padding:0 8px 8px;}
-.wt-cal-entry{display:flex;justify-content:space-between;align-items:center;padding:4px 0;}
-.wt-cal-entry .actions{display:flex;gap:4px;}
-.wt-cal-entry button{font-size:.8rem;}
-.wt-cal-add .add-row{display:flex;flex-direction:column;gap:4px;margin-top:4px;}
-.wt-cal-add input{width:100%;}
-.wt-cal-error{color:#d00;font-size:.75rem;}
-.wt-cal-live{position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;}
-`;
-    document.head.appendChild(style);
+function loadHistory() {
+  try { return JSON.parse(localStorage.getItem(HISTORY_KEY)) || {}; }
+  catch (e) { return {}; }
+}
 
-    // live region
+function saveHistory(data) {
+  localStorage.setItem(HISTORY_KEY, JSON.stringify(data));
+}
+
+function getDayStats(dayISO) {
+  const hist = loadHistory();
+  return parseHistoryLines(hist[dayISO] || []);
+}
+
+function getMonthGrid(date) {
+  const first = new Date(date.getFullYear(), date.getMonth(), 1);
+  const start = new Date(first);
+  start.setDate(first.getDate() - first.getDay());
+  const days = [];
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    days.push({
+      date: d,
+      iso: d.toISOString().slice(0, 10),
+      inMonth: d.getMonth() === first.getMonth()
+    });
+  }
+  return days;
+}
+
+let currentMonthDate = new Date();
+let undoPayload = null;
+
+function announce(msg) {
+  const live = document.getElementById('wt-cal-live');
+  if (live) {
+    live.textContent = '';
+    setTimeout(() => { live.textContent = msg; }, 10);
+  }
+}
+
+function mountCalendar() {
+  if (typeof document === 'undefined') return;
+  const prev = document.getElementById('wt-cal');
+  if (prev && prev.parentNode) prev.parentNode.removeChild(prev);
+  const section = document.createElement('section');
+  section.id = 'wt-cal';
+  section.className = 'wt-cal';
+  const historyArea = document.querySelector('#history, #wt-history, .history');
+  if (historyArea && historyArea.parentNode) historyArea.parentNode.insertBefore(section, historyArea.nextSibling);
+  else document.body.appendChild(section);
+  if (!document.getElementById('wt-cal-live')) {
     const live = document.createElement('div');
-    live.className='wt-cal-live';
-    live.setAttribute('role','status');
-    live.setAttribute('aria-live','polite');
+    live.id = 'wt-cal-live';
+    live.setAttribute('aria-live', 'polite');
+    live.className = 'sr-only';
     document.body.appendChild(live);
-    function announce(msg){ live.textContent=''; setTimeout(()=>{ live.textContent=msg; },10); }
-
-    // data
-    const STORAGE_KEY='wt_history';
-    let rawHistory={};
-    try{ rawHistory = JSON.parse(localStorage.getItem(STORAGE_KEY)) || {}; }catch(e){ rawHistory = {}; }
-    let undoSnapshot=null;
-    let saveTimer=null;
-    function scheduleSave(){
-      clearTimeout(saveTimer);
-      saveTimer = setTimeout(()=>{ localStorage.setItem(STORAGE_KEY, JSON.stringify(rawHistory)); },80);
-    }
-    function getEntries(date){
-      const v = rawHistory[date];
-      return Array.isArray(v)? v.slice() : [];
-    }
-
-    // helpers
-    function formatHuman(dateStr){ return parseDateLocal(dateStr).toLocaleDateString(undefined,{weekday:'short',year:'numeric',month:'short',day:'numeric'}); }
-
-    const cards=[];
-
-    function offerUndo(message, snapshot){
-      undoSnapshot = snapshot;
-      if(typeof showToast === 'function'){
-        showToast(message, { actionLabel:'Undo', onAction: undo });
-        setTimeout(()=>{ undoSnapshot=null; },8000);
-      } else {
-        const bar = document.createElement('div');
-        bar.style.position='fixed';bar.style.bottom='10px';bar.style.left='50%';bar.style.transform='translateX(-50%)';
-        bar.style.background='#333';bar.style.color='#fff';bar.style.padding='8px';bar.style.borderRadius='4px';
-        const btn=document.createElement('button');btn.textContent='Undo';btn.style.marginLeft='8px';
-        btn.addEventListener('click',()=>{ undo(); document.body.removeChild(bar); });
-        bar.textContent=message; bar.appendChild(btn);
-        document.body.appendChild(bar);
-        setTimeout(()=>{ if(bar.parentNode) bar.parentNode.removeChild(bar); undoSnapshot=null; },8000);
-      }
-    }
-    function undo(){
-      if(!undoSnapshot) return;
-      rawHistory = JSON.parse(undoSnapshot);
-      undoSnapshot=null;
-      scheduleSave();
-      renderDays();
-      announce('Undo complete.');
-    }
-
-    document.addEventListener('keydown', e=>{
-      if((e.ctrlKey||e.metaKey) && e.key.toLowerCase()==='z'){
-        if(undoSnapshot){ e.preventDefault(); undo(); }
-      }
-    });
-
-    // controls
-    mount.innerHTML='';
-    const controls = document.createElement('div');
-    controls.className='wt-cal-controls';
-    const expandAll = document.createElement('button');
-    expandAll.type='button'; expandAll.textContent='Expand All';
-    const collapseAll = document.createElement('button');
-    collapseAll.type='button'; collapseAll.textContent='Collapse All';
-    controls.appendChild(expandAll); controls.appendChild(collapseAll);
-    mount.appendChild(controls);
-
-    const container = document.createElement('div');
-    mount.appendChild(container);
-
-    expandAll.addEventListener('click', ()=>{
-      cards.forEach(c=>{ c.header.setAttribute('aria-expanded','true'); c.body.style.display=''; c.build(true); });
-    });
-    collapseAll.addEventListener('click', ()=>{
-      cards.forEach(c=>{ c.header.setAttribute('aria-expanded','false'); c.body.style.display='none'; });
-    });
-
-    function renderDays(){
-      container.innerHTML='';
-      cards.length=0;
-      const dates = Object.keys(rawHistory).sort((a,b)=>b.localeCompare(a)).slice(0,90);
-      if(dates.length===0){ container.textContent='No history'; return; }
-      dates.forEach((date, idx)=>{
-        const card = createDayCard(date, idx<7, idx<14);
-        container.appendChild(card.el);
-        cards.push(card);
-      });
-    }
-
-    function createDayCard(date, expandedDefault, buildNow){
-      const cardEl = document.createElement('div'); cardEl.className='wt-cal-day';
-      const header = document.createElement('button');
-      header.type='button';
-      header.className='wt-cal-day-header';
-      header.setAttribute('aria-expanded', expandedDefault? 'true':'false');
-      const dateSpan=document.createElement('span'); dateSpan.textContent=formatHuman(date);
-      const totalsSpan=document.createElement('span'); totalsSpan.className='wt-cal-totals';
-      const chev=document.createElement('span'); chev.className='wt-cal-chevron'; chev.textContent='▾';
-      header.appendChild(dateSpan); header.appendChild(totalsSpan); header.appendChild(chev);
-      cardEl.appendChild(header);
-      const body=document.createElement('div'); body.className='wt-cal-day-body';
-      if(!expandedDefault) body.style.display='none';
-      cardEl.appendChild(body);
-
-      function refreshTotals(){
-        const t = computeDayTotals(getEntries(date));
-        totalsSpan.textContent = `Sets: ${t.sets} • Volume: ${t.volume} lbs`;
-      }
-
-      let built=false;
-      function build(force=false){
-        if(built && !force) return;
-        body.innerHTML='';
-        const ul=document.createElement('ul');
-        getEntries(date).forEach((line,i)=>{ ul.appendChild(createEntry(date,line,i)); });
-        body.appendChild(ul);
-        body.appendChild(createAddRow(date));
-        built=true;
-      }
-
-      if(expandedDefault && buildNow) build();
-
-      header.addEventListener('click', ()=>{
-         const exp = header.getAttribute('aria-expanded')==='true';
-         header.setAttribute('aria-expanded', exp? 'false':'true');
-         if(exp){ body.style.display='none'; }
-         else { body.style.display=''; build(); }
-      });
-
-      const card={ el:cardEl, header, body, build, refreshTotals };
-      refreshTotals();
-      return card;
-
-      function createEntry(date,line,index){
-        const li=document.createElement('li'); li.className='wt-cal-entry';
-        const span=document.createElement('span'); span.textContent=line; li.appendChild(span);
-        const actions=document.createElement('span'); actions.className='actions'; li.appendChild(actions);
-        const edit=document.createElement('button'); edit.type='button'; edit.textContent='Edit'; edit.setAttribute('aria-label','Edit entry'); actions.appendChild(edit);
-        const del=document.createElement('button'); del.type='button'; del.textContent='Del'; del.setAttribute('aria-label','Delete entry'); actions.appendChild(del);
-
-        edit.addEventListener('click', ()=>enterEdit());
-        del.addEventListener('click', ()=>{
-          const prev = JSON.stringify(rawHistory);
-          const arr = getEntries(date);
-          arr.splice(index,1);
-          if(arr.length) rawHistory[date]=arr; else delete rawHistory[date];
-          scheduleSave();
-          announce('Deleted entry.');
-          offerUndo('Entry deleted', prev);
-          build(true);
-          refreshTotals();
-        });
-
-        function enterEdit(){
-          const input=document.createElement('input'); input.type='text'; input.value=line;
-          input.className='wt-cal-edit';
-          li.insertBefore(input, span); li.removeChild(span);
-          edit.style.display='none';
-          const err=document.createElement('div'); err.className='wt-cal-error'; li.appendChild(err);
-          input.focus();
-          function save(){
-            const val=input.value.trim();
-            if(!val){ err.textContent='Required'; return; }
-            const parsed=parseHistoryLine(val);
-            if(!parsed){
-              err.textContent='Invalid format';
-              if(!confirm('Invalid format. Keep as free text?')) return;
-            }
-            const prev = JSON.stringify(rawHistory);
-            const arr = getEntries(date);
-            arr[index]=val;
-            rawHistory[date]=arr;
-            scheduleSave();
-            announce('Edited entry on '+formatHuman(date)+'.');
-            offerUndo('Entry updated', prev);
-            build(true);
-            refreshTotals();
-          }
-          function cancel(){ err.remove(); build(true); }
-          input.addEventListener('keydown', e=>{
-            if(e.key==='Enter'){ e.preventDefault(); save(); }
-            else if(e.key==='Escape'){ e.preventDefault(); cancel(); }
-          });
-        }
-
-        return li;
-      }
-
-      function createAddRow(date){
-        const wrap=document.createElement('div'); wrap.className='wt-cal-add';
-        const btn=document.createElement('button'); btn.type='button'; btn.textContent='+ Add'; wrap.appendChild(btn);
-        let row=null;
-        btn.addEventListener('click', ()=>{
-          if(row) return;
-          btn.style.display='none';
-          row=document.createElement('div'); row.className='add-row';
-          const input=document.createElement('input'); input.type='text'; input.placeholder='Exercise: 100 lbs × 5 reps';
-          const err=document.createElement('div'); err.className='wt-cal-error';
-          row.appendChild(input); row.appendChild(err); wrap.appendChild(row); input.focus();
-          function save(){
-            const val=input.value.trim();
-            if(!val){ err.textContent='Required'; return; }
-            const parsed=parseHistoryLine(val);
-            if(!parsed){
-              err.textContent='Invalid format';
-              if(!confirm('Invalid format. Keep as free text?')) return;
-            }
-            const prev = JSON.stringify(rawHistory);
-            const arr=getEntries(date);
-            arr.push(val);
-            rawHistory[date]=arr;
-            scheduleSave();
-            announce('Added entry.');
-            offerUndo('Entry added', prev);
-            build(true);
-            refreshTotals();
-            row.remove(); row=null; btn.style.display='';
-            setTimeout(()=>{
-              const items=body.querySelectorAll('li');
-              if(items.length) items[items.length-1].scrollIntoView({behavior:'smooth',block:'center'});
-            },50);
-          }
-          function cancel(){ row.remove(); row=null; btn.style.display=''; }
-          input.addEventListener('keydown', e=>{
-            if(e.key==='Enter'){ e.preventDefault(); save(); }
-            else if(e.key==='Escape'){ e.preventDefault(); cancel(); }
-          });
-        });
-        return wrap;
-      }
-    }
-
-    renderDays();
-  });
+  }
+  currentMonthDate = new Date();
+  renderCalendar(currentMonthDate);
 }
 
-// for tests
-if(typeof module !== 'undefined'){ module.exports = { parseHistoryLine, computeDayTotals, parseDateLocal, parseAiText, snapshotToLines }; }
+function renderCalendar(date) {
+  const mount = document.getElementById('wt-cal');
+  if (!mount) return;
+  currentMonthDate = new Date(date.getFullYear(), date.getMonth(), 1);
+  mount.innerHTML = '';
+
+  const header = document.createElement('div');
+  header.className = 'cal-header';
+  const prevBtn = document.createElement('button'); prevBtn.className = 'btn'; prevBtn.textContent = '« Prev';
+  const title = document.createElement('div'); title.className = 'cal-title';
+  title.textContent = currentMonthDate.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+  const nextBtn = document.createElement('button'); nextBtn.className = 'btn'; nextBtn.textContent = 'Next »';
+  const todayBtn = document.createElement('button'); todayBtn.className = 'btn'; todayBtn.textContent = 'Today';
+  header.appendChild(prevBtn); header.appendChild(title); header.appendChild(nextBtn); header.appendChild(todayBtn);
+  mount.appendChild(header);
+
+  const dowRow = document.createElement('div'); dowRow.className = 'grid';
+  ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].forEach(d => {
+    const el = document.createElement('div'); el.className = 'dow'; el.textContent = d; dowRow.appendChild(el);
+  });
+  mount.appendChild(dowRow);
+
+  const grid = document.createElement('div');
+  grid.className = 'grid';
+  grid.setAttribute('role', 'grid');
+  mount.appendChild(grid);
+
+  const days = getMonthGrid(currentMonthDate);
+  const cells = [];
+  days.forEach(day => {
+    const cell = document.createElement('div');
+    cell.className = 'cell' + (day.inMonth ? '' : ' out');
+    cell.setAttribute('role', 'gridcell');
+    cell.dataset.iso = day.iso;
+    const daynum = document.createElement('div'); daynum.className = 'daynum'; daynum.textContent = day.date.getDate();
+    cell.appendChild(daynum);
+    const stats = getDayStats(day.iso);
+    if (stats.sets > 0) {
+      const badges = document.createElement('div'); badges.className = 'badges';
+      const s = document.createElement('span'); s.className = 'badge'; s.textContent = `S: ${stats.sets}`;
+      const v = document.createElement('span'); v.className = 'badge'; v.textContent = `V: ${stats.volume}`;
+      badges.appendChild(s); badges.appendChild(v); cell.appendChild(badges);
+    }
+    const card = document.createElement('div'); card.className = 'card'; card.style.display = 'none'; cell.appendChild(card);
+    cell.addEventListener('click', e => { if (e.target.closest('button')) return; toggleCard(cell, day); });
+    cells.push(cell); grid.appendChild(cell);
+  });
+
+  announce(`Month changed to ${title.textContent}`);
+
+  prevBtn.addEventListener('click', () => { const d = new Date(currentMonthDate); d.setMonth(d.getMonth() - 1); renderCalendar(d); });
+  nextBtn.addEventListener('click', () => { const d = new Date(currentMonthDate); d.setMonth(d.getMonth() + 1); renderCalendar(d); });
+  todayBtn.addEventListener('click', () => {
+    const today = new Date();
+    renderCalendar(today);
+    const iso = today.toISOString().slice(0, 10);
+    const c = grid.querySelector(`[data-iso="${iso}"]`);
+    if (c) { focusCell(c); c.scrollIntoView({ behavior: 'smooth', block: 'center' }); }
+  });
+
+  let focusEl = grid.querySelector(`[data-iso="${new Date().toISOString().slice(0,10)}"]`) || cells[0];
+  focusCell(focusEl);
+
+  grid.addEventListener('keydown', e => {
+    const idx = cells.indexOf(document.activeElement);
+    let n = idx;
+    if (e.key === 'ArrowRight') { n = idx + 1; e.preventDefault(); }
+    else if (e.key === 'ArrowLeft') { n = idx - 1; e.preventDefault(); }
+    else if (e.key === 'ArrowDown') { n = idx + 7; e.preventDefault(); }
+    else if (e.key === 'ArrowUp') { n = idx - 7; e.preventDefault(); }
+    else if (e.key === 'Enter') { e.preventDefault(); toggleCard(cells[idx], days[idx], true); return; }
+    else if (e.key === 'Escape') { e.preventDefault(); const card = document.activeElement.querySelector('.card'); if (card) card.style.display = 'none'; return; }
+    if (n >= 0 && n < cells.length && n !== idx) focusCell(cells[n]);
+  });
+
+  function focusCell(el) {
+    cells.forEach(c => { c.tabIndex = -1; c.setAttribute('aria-selected', 'false'); });
+    el.tabIndex = 0; el.setAttribute('aria-selected', 'true'); el.focus();
+  }
+
+  function toggleCard(cell, day, fromKeyboard) {
+    const card = cell.querySelector('.card');
+    if (card.style.display === 'none' || !card.style.display) {
+      buildCard(card, day);
+      card.style.display = '';
+      if (fromKeyboard) {
+        const stats = getDayStats(day.iso);
+        announce(`Opened ${day.date.toLocaleDateString(undefined,{weekday:'short',month:'short',day:'numeric'})}: ${stats.sets} sets, ${stats.volume} lbs volume`);
+      }
+    } else {
+      card.style.display = 'none';
+    }
+  }
+
+  function buildCard(card, day) {
+    card.innerHTML = '';
+    const stats = getDayStats(day.iso);
+    if (!stats.entries.length) { card.textContent = 'No entries'; return; }
+    stats.entries.forEach((en, idx) => {
+      const row = document.createElement('div'); row.className = 'entry';
+      const text = document.createElement('span'); text.textContent = en.text;
+      const actions = document.createElement('span'); actions.className = 'actions';
+      const editBtn = document.createElement('button'); editBtn.className = 'btn'; editBtn.textContent = 'Edit';
+      editBtn.addEventListener('click', () => {
+        const val = window.prompt('Edit entry', en.text);
+        if (val == null || val === en.text) return;
+        if (!parseHistoryLine(val)) {
+          if (typeof showToast === 'function') showToast('Invalid format. Use ‘Bench Press: 185 lbs × 5 reps’');
+          else alert('Invalid format. Use “Bench Press: 185 lbs × 5 reps”');
+          return;
+        }
+        const hist = loadHistory();
+        const arr = hist[day.iso] || [];
+        arr[idx] = val; hist[day.iso] = arr; saveHistory(hist); renderCalendar(currentMonthDate);
+      });
+      const delBtn = document.createElement('button'); delBtn.className = 'btn'; delBtn.textContent = 'Del';
+      delBtn.addEventListener('click', () => {
+        const hist = loadHistory();
+        const arr = hist[day.iso] || [];
+        const removed = arr.splice(idx, 1)[0];
+        if (arr.length) hist[day.iso] = arr; else delete hist[day.iso];
+        saveHistory(hist);
+        const payload = { dayISO: day.iso, lineText: removed };
+        if (typeof pushUndo === 'function') pushUndo({ type: 'cal-del', payload });
+        else undoPayload = payload;
+        const onUndo = () => {
+          if (typeof performUndo === 'function') performUndo();
+          else if (undoPayload) {
+            const h = loadHistory();
+            h[undoPayload.dayISO] = h[undoPayload.dayISO] || [];
+            h[undoPayload.dayISO].push(undoPayload.lineText);
+            saveHistory(h);
+            undoPayload = null;
+            renderCalendar(currentMonthDate);
+          }
+        };
+        if (typeof showToast === 'function') showToast('Entry deleted', { actionLabel: 'Undo', onAction: onUndo });
+        else if (confirm('Entry deleted. Undo?')) onUndo();
+        renderCalendar(currentMonthDate);
+      });
+      actions.appendChild(editBtn); actions.appendChild(delBtn);
+      row.appendChild(text); row.appendChild(actions);
+      card.appendChild(row);
+    });
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.mountCalendar = mountCalendar;
+  document.addEventListener('DOMContentLoaded', () => { mountCalendar(); });
+}
+
+// exports for tests
+if (typeof module !== 'undefined') {
+  module.exports = {
+    parseHistoryLine,
+    computeDayTotals,
+    parseDateLocal,
+    parseAiText,
+    snapshotToLines,
+    parseHistoryLines,
+    getDayStats,
+    getMonthGrid,
+    mountCalendar
+  };
+}
+

--- a/style.css
+++ b/style.css
@@ -291,3 +291,33 @@ body.dark #calendarSection{
   #repeatLastBtn { border-color:#333; color:#ddd; }
 }
 
+.wt-cal { margin-top: 16px; border-radius: 12px; background: var(--panel, #fff4); padding: 12px; }
+.wt-cal .cal-header { display: grid; grid-template-columns: auto 1fr auto auto; gap: 8px; align-items: center; margin-bottom: 8px; }
+.wt-cal .cal-title { text-align: center; font-weight: 600; }
+.wt-cal .btn { padding: 8px 12px; min-height: 40px; }
+.wt-cal .grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 6px; }
+.wt-cal .dow { text-align: center; font-size: 12px; color: var(--muted-fg, #777); padding: 6px 0; }
+.wt-cal .cell { border: 1px solid var(--hairline, #e5e5e5); border-radius: 10px; min-height: 68px; padding: 6px; position: relative; background: var(--bg, #fff); }
+.wt-cal .cell.out { opacity: 0.45; }
+.wt-cal .daynum { font-size: 12px; color: var(--muted-fg, #777); }
+.wt-cal .badges { margin-top: 4px; display: flex; gap: 6px; flex-wrap: wrap; }
+.wt-cal .badge { font-size: 11px; padding: 2px 6px; border-radius: 999px; background: var(--panel, #f5f5f5); border: 1px solid var(--hairline, #e5e5e5); }
+.wt-cal .cell[aria-selected="true"] { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #4a90e2) 25%, transparent); }
+.wt-cal .card { margin-top: 6px; border-top: 1px dashed var(--hairline, #e5e5e5); padding-top: 6px; max-height: 200px; overflow: auto; }
+.wt-cal .entry { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 4px 0; font-size: 14px; }
+.wt-cal .entry .actions { display: flex; gap: 6px; }
+.wt-cal .sr-only { position: absolute; left: -9999px; width: 1px; height: 1px; overflow: hidden; }
+
+@media (max-width: 768px) {
+  .wt-cal .cell { min-height: 72px; }
+  .wt-cal .btn { min-height: 44px; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .wt-cal { background: #1a1a1a; }
+  .wt-cal .cell { background: #111; border-color: #333; }
+  .wt-cal .badge { background: #161616; border-color: #333; }
+  .wt-cal .dow, .wt-cal .daynum { color: #aaa; }
+}
+
+

--- a/tests/calendar.test.js
+++ b/tests/calendar.test.js
@@ -1,4 +1,4 @@
-const { parseDateLocal, parseAiText, snapshotToLines } = require('../calendar');
+const { parseDateLocal, parseAiText, snapshotToLines, parseHistoryLines, getMonthGrid, getDayStats } = require('../calendar');
 
 test('parseDateLocal returns exact date', () => {
   const d = parseDateLocal('2025-08-01');
@@ -36,4 +36,39 @@ test('snapshotToLines retains duplicate sets with numbering', () => {
     'Bench Press: Set 1 - 185 lbs × 5 reps',
     'Bench Press: Set 2 - 185 lbs × 5 reps'
   ]);
+});
+
+test('parseHistoryLines parses valid lines and ignores invalid', () => {
+  const result = parseHistoryLines([
+    'Bench Press: 100 lbs × 5 reps',
+    'oops'
+  ]);
+  expect(result.sets).toBe(1);
+  expect(result.volume).toBe(500);
+  expect(result.entries).toEqual([
+    { text: 'Bench Press: 100 lbs × 5 reps', lift: 'Bench Press', weight: 100, reps: 5 }
+  ]);
+});
+
+test('getMonthGrid returns 42 days with correct boundaries', () => {
+  const grid = getMonthGrid(new Date('2024-02-15'));
+  expect(grid).toHaveLength(42);
+  expect(grid[0].iso).toBe('2024-01-28');
+  expect(grid[41].iso).toBe('2024-03-09');
+  expect(grid[0].inMonth).toBe(false);
+  expect(grid[10].inMonth).toBe(true);
+});
+
+test('getDayStats reads from localStorage', () => {
+  localStorage.clear();
+  localStorage.setItem('wt_history', JSON.stringify({
+    '2024-08-18': [
+      'Bench Press: 100 lbs × 5 reps',
+      'Squat: 150 lbs × 3 reps'
+    ]
+  }));
+  const stats = getDayStats('2024-08-18');
+  expect(stats.sets).toBe(2);
+  expect(stats.volume).toBe(100 * 5 + 150 * 3);
+  expect(stats.entries.length).toBe(2);
 });


### PR DESCRIPTION
## Summary
- Build new month calendar renderer with navigation, day cards, edit/delete, keyboard and accessibility hooks
- Add helpers parseHistoryLines, getMonthGrid, getDayStats powered by `wt_history`
- Append responsive and dark-mode styles for calendar grid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae34309cd8833283a10e753cbd851c