### PR TITLE
Add volume chart module and integrate with calendar

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -123,7 +123,10 @@ if (typeof document !== 'undefined') {
     let saveTimer=null;
     function scheduleSave(){
       clearTimeout(saveTimer);
-      saveTimer = setTimeout(()=>{ localStorage.setItem(STORAGE_KEY, JSON.stringify(rawHistory)); },80);
+      saveTimer = setTimeout(()=>{
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(rawHistory));
+        if (typeof renderVolumeChart === 'function') renderVolumeChart();
+      },80);
     }
     function getEntries(date){
       const v = rawHistory[date];
@@ -191,12 +194,17 @@ if (typeof document !== 'undefined') {
       container.innerHTML='';
       cards.length=0;
       const dates = Object.keys(rawHistory).sort((a,b)=>b.localeCompare(a)).slice(0,90);
-      if(dates.length===0){ container.textContent='No history'; return; }
+      if(dates.length===0){
+        container.textContent='No history';
+        if (typeof renderVolumeChart === 'function') renderVolumeChart();
+        return;
+      }
       dates.forEach((date, idx)=>{
         const card = createDayCard(date, idx<7, idx<14);
         container.appendChild(card.el);
         cards.push(card);
       });
+      if (typeof renderVolumeChart === 'function') renderVolumeChart();
     }
 
     function createDayCard(date, expandedDefault, buildNow){

--- a/charts.js
+++ b/charts.js
@@ -1,0 +1,66 @@
+const LINE_RE = /^(.*?):\s*(\d+(?:\.\d+)?)\s*\w*\s*[×x]\s*(\d+)\s*reps/i;
+
+function readHistory(){
+  if (typeof localStorage === 'undefined') return {};
+  try {
+    return JSON.parse(localStorage.getItem('wt_history')) || {};
+  } catch(e){
+    return {};
+  }
+}
+
+function computeDay(lines){
+  let volume = 0; let sets = 0;
+  (Array.isArray(lines)? lines: []).forEach(line => {
+    const m = String(line).match(LINE_RE);
+    if (m){
+      const weight = parseFloat(m[2]);
+      const reps = parseInt(m[3],10);
+      if (!isNaN(weight) && !isNaN(reps)){
+        volume += weight * reps;
+        sets += 1;
+      }
+    }
+  });
+  return { volume, sets };
+}
+
+function buildDatasets(history){
+  const labels = Object.keys(history||{}).sort();
+  const volumes = [];
+  const sets = [];
+  labels.forEach(date => {
+    const stats = computeDay(history[date]);
+    volumes.push(stats.volume);
+    sets.push(stats.sets);
+  });
+  return { labels, volumes, sets };
+}
+
+function renderVolumeChart(){
+  if (typeof document === 'undefined') return;
+  const canvas = document.getElementById('volumeChart');
+  if (!canvas) return;
+  const ctx = canvas.getContext && canvas.getContext('2d');
+  if (!ctx) return;
+  const data = buildDatasets(readHistory());
+  const width = canvas.width = 300;
+  const height = canvas.height = 150;
+  ctx.clearRect(0,0,width,height);
+  if (data.volumes.length === 0) return;
+  const max = Math.max(...data.volumes);
+  const barWidth = width / data.volumes.length;
+  data.volumes.forEach((v,i) => {
+    const barHeight = max? (v/max)*(height-20):0;
+    ctx.fillStyle = '#3b82f6';
+    ctx.fillRect(i*barWidth + 1, height - barHeight, barWidth - 2, barHeight);
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.renderVolumeChart = renderVolumeChart;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { readHistory, buildDatasets, renderVolumeChart };
+}

--- a/index.html
+++ b/index.html
@@ -127,6 +127,9 @@
 
       <button id="exportBtn" class="btn btn-export">Export (JSON + AI + CSV)</button>
 
+      <h3>Progress Charts</h3>
+      <canvas id="volumeChart" width="300" height="150"></canvas>
+
     </div>
   </div>
   <div class="footer-space"></div>
@@ -138,6 +141,7 @@
   </button>
 
 <script src="script.js"></script>
+<script src="charts.js"></script>
 <script src="calendar.js"></script>
 </body>
 </html>

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -1,0 +1,29 @@
+const { buildDatasets, renderVolumeChart } = require('../charts');
+
+beforeEach(() => {
+  localStorage.clear();
+  document.body.innerHTML = '';
+});
+
+test('buildDatasets aggregates volume and sets per day', () => {
+  const history = {
+    '2024-01-01': ['Bench: 100 lbs × 5 reps', 'Squat: 200 lbs × 5 reps'],
+    '2024-01-02': ['Bench: 100 lbs × 3 reps']
+  };
+  const ds = buildDatasets(history);
+  expect(ds.labels).toEqual(['2024-01-01', '2024-01-02']);
+  expect(ds.volumes).toEqual([100*5 + 200*5, 100*3]);
+  expect(ds.sets).toEqual([2,1]);
+});
+
+test('renderVolumeChart draws on canvas using stored history', () => {
+  const history = { '2024-01-01': ['Bench: 100 lbs × 5 reps'] };
+  localStorage.setItem('wt_history', JSON.stringify(history));
+  document.body.innerHTML = '<canvas id="volumeChart"></canvas>';
+  const c = document.getElementById('volumeChart');
+  c.getContext = () => ({ clearRect(){}, fillRect(){} });
+  expect(() => renderVolumeChart()).not.toThrow();
+  const canvas = document.getElementById('volumeChart');
+  expect(canvas.width).toBeGreaterThan(0);
+  expect(canvas.height).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- Add `charts.js` to compute daily volume and sets from `wt_history` and render a simple bar chart.
- Embed a canvas and load the charts module in `index.html` for progress visualization.
- Trigger chart updates from `calendar.js` whenever history changes.
- Cover dataset aggregation and rendering logic with new Jest tests.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae572aa0f48332a527c130550a5a76