### PR TITLE
feat: add workout templates with persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,22 @@
         <button id="beginSuperset" class="btn btn-primary">Begin Superset</button>
       </div>
 
+      <!-- Templates -->
+      <div id="templateManager" style="margin-bottom:12px;">
+        <div class="inline-row" style="margin-bottom:6px;">
+          <select id="templateSelect" class="field">
+            <option value="">Select Template</option>
+          </select>
+          <button id="loadTemplateBtn" class="btn btn-secondary" style="flex:0 0 80px;">Load</button>
+        </div>
+        <div class="inline-row" style="margin-bottom:6px;">
+          <input type="text" id="templateName" class="field" placeholder="Template Name">
+          <button id="saveTemplateBtn" class="btn btn-secondary" style="flex:0 0 80px;">Save</button>
+        </div>
+        <textarea id="templateExercises" class="field" placeholder="Exercises (one per line)" style="margin-bottom:6px;"></textarea>
+        <button id="deleteTemplateBtn" class="btn btn-reset">Delete Template</button>
+      </div>
+
       <!-- Exercise search & filters -->
       <input type="text" id="exerciseSearch" list="exerciseList" placeholder="Search exercises" class="field" style="margin-bottom:6px;">
       <datalist id="exerciseList"></datalist>

--- a/tests/templates.test.js
+++ b/tests/templates.test.js
@@ -1,0 +1,34 @@
+const { saveTemplate, loadTemplate, wtStorage, WT_KEYS } = require('../script.js');
+
+describe('templates', () => {
+  beforeEach(() => {
+    wtStorage.clear(WT_KEYS.templates);
+  });
+
+  test('serialize and deserialize template', () => {
+    const exs = [
+      { name: 'Bench Press', isCardio: false, isSuperset: false, sets: [] },
+      { name: 'Squat', isCardio: false, isSuperset: false, sets: [] },
+    ];
+    saveTemplate('push', exs);
+    const stored = wtStorage.get(WT_KEYS.templates, {});
+    expect(Array.isArray(stored.push)).toBe(true);
+    expect(stored.push[0].name).toBe('Bench Press');
+
+    const loaded = loadTemplate('push');
+    expect(loaded.length).toBe(2);
+    expect(loaded[0]).toMatchObject(exs[0]);
+  });
+
+  test('loaded template populates exercises', () => {
+    const exs = [
+      { name: 'Deadlift', isCardio: false, isSuperset: false, sets: [] },
+    ];
+    saveTemplate('pull', exs);
+    const session = { exercises: [], startedAt: null };
+    session.exercises = loadTemplate('pull');
+    expect(session.exercises.length).toBe(1);
+    expect(session.exercises[0].name).toBe('Deadlift');
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend storage keys with `wt_templates` and helper functions to save, load and delete templates
- add template management UI for creating, editing, deleting and loading workouts
- cover template serialization and session population with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae572bb4ac8332880dea134b747571