### PR TITLE
Add personal record and goal tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,17 @@
         <div class="notice">Autosaves locally. Export when finished.</div>
       </div>
 
+      <div id="prGoalSection">
+        <h3>Goals & PRs</h3>
+        <div id="prList"></div>
+        <div class="inline-row" style="margin-top:6px;">
+          <input type="text" id="goalExercise" class="field" placeholder="Exercise">
+          <input type="number" id="goalWeight" class="field" placeholder="Goal Weight" min="0">
+          <button id="saveGoal" class="btn btn-secondary" style="flex:0 0 80px;">Save</button>
+        </div>
+        <div id="goalList" style="margin-top:6px;"></div>
+      </div>
+
       <div id="calendarSection">
         <h3>Workout History</h3>
         <div class="calendar-nav">

--- a/tests/pr_goals.test.js
+++ b/tests/pr_goals.test.js
@@ -1,0 +1,25 @@
+const { checkAndUpdatePR, setGoal, clearPRsGoals, wtStorage, WT_KEYS } = require('../script');
+
+describe('PRs and Goals', () => {
+  beforeEach(() => {
+    clearPRsGoals();
+  });
+
+  test('updates PR when surpassed', () => {
+    checkAndUpdatePR('Bench', 100, 5); // initial PR
+    const res = checkAndUpdatePR('Bench', 120, 5);
+    expect(res.prUpdated).toBe(true);
+    const prs = wtStorage.get(WT_KEYS.prs, {});
+    expect(prs.Bench.weight).toBe(120);
+    expect(prs.Bench.reps).toBe(5);
+  });
+
+  test('triggers notification when goal met', () => {
+    setGoal('Squat', 200);
+    const msgs = [];
+    global.showToast = (m) => msgs.push(m);
+    const res = checkAndUpdatePR('Squat', 200, 5);
+    expect(res.goalMet).toBe(true);
+    expect(msgs.some((m) => /Goal met/.test(m))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- store personal records and workout goals in local storage
- surface goals and current PRs in the UI with editing controls
- update PRs and notify when goals are achieved

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae572d46f48332ac1c93e1a8a8af69