### PR TITLE
Add personal records and goal tracking with UI and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,15 @@
 
       <button id="exportBtn" class="btn btn-export">Export (JSON + AI + CSV)</button>
 
+      <div id="goalsPrsSection">
+        <h3>Goals</h3>
+        <textarea id="goalsInput" class="field" placeholder="Bench Press: 200"></textarea>
+        <button id="saveGoalsBtn" class="btn btn-secondary" style="margin-top:6px;">Save Goals</button>
+        <h3>Personal Records</h3>
+        <textarea id="prsInput" class="field" placeholder="Bench Press: 185"></textarea>
+        <button id="savePrsBtn" class="btn btn-secondary" style="margin-top:6px;">Save PRs</button>
+      </div>
+
       <h3>Progress Charts</h3>
       <canvas id="volumeChart" width="300" height="150"></canvas>
 

--- a/tests/prs-goals.test.js
+++ b/tests/prs-goals.test.js
@@ -1,0 +1,24 @@
+const { checkPrAndGoal, wtStorage, WT_KEYS } = require('../script');
+
+describe('PR and Goals', () => {
+  beforeEach(() => {
+    wtStorage.clear(WT_KEYS.prs);
+    wtStorage.clear(WT_KEYS.goals);
+    global.showToast = jest.fn();
+  });
+
+  test('updates PR when surpassed', () => {
+    wtStorage.set(WT_KEYS.prs, { 'Bench Press': 100 });
+    const res = checkPrAndGoal('Bench Press', 110);
+    expect(res.prUpdated).toBe(true);
+    expect(wtStorage.get(WT_KEYS.prs, {})['Bench Press']).toBe(110);
+    expect(global.showToast).toHaveBeenCalledWith(expect.stringContaining('PR'));
+  });
+
+  test('triggers goal notification when met', () => {
+    wtStorage.set(WT_KEYS.goals, { Squat: 200 });
+    const res = checkPrAndGoal('Squat', 205);
+    expect(res.goalMet).toBe(true);
+    expect(global.showToast).toHaveBeenCalledWith(expect.stringContaining('Goal'));
+  });
+});


### PR DESCRIPTION
## Summary
- track personal records and goals in local storage
- update PRs and trigger goal notifications when logging sets
- add simple UI to view and edit goals and current PRs
- cover PR and goal logic with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae59c56da88332aeee894f12f2e294