### PR TITLE
chore(calendar): restore classic calendar UI/behavior; keep tests passing

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -1,358 +1,443 @@
-/**
- * Lightweight calendar/history renderer injected without HTML changes.
- * Provides collapsible day cards with inline editing, quick add,
- * delete and undo. Everything is mounted dynamically.
- */
+// Classic calendar implementation with month grid and history management
+// Provides public helpers for tests: parseDateLocal, parseAiText, parseCsv,
+// snapshotToLines and mergeHistory.
 
+// ---------- Helpers ----------
+
+const STORAGE_KEY = 'wt_history';
+
+function pad(n) {
+  return n.toString().padStart(2, '0');
+}
+
+function formatDate(date) {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+function parseDateLocal(str) {
+  const [y, m, d] = String(str).split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function safeParseJson(str) {
+  try { return JSON.parse(str); } catch { return null; }
+}
+
+function extractJsonFromText(text) {
+  if (!text) return null;
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end === -1) return null;
+  return safeParseJson(text.slice(start, end + 1));
+}
+
+// Line parsing helpers for history entries
 const LINE_RE = /^(.*?):\s*(\d+(?:\.\d+)?)\s*lbs\s*[×x]\s*(\d+)\s*reps\s*$/i;
-function parseHistoryLine(str){
-  const m = String(str||'').match(LINE_RE);
-  if(!m) return null;
+function parseHistoryLine(str) {
+  const m = String(str || '').match(LINE_RE);
+  if (!m) return null;
   return { name: m[1].trim(), weight: +m[2], reps: +m[3] };
 }
 
-function parseDateLocal(str){
-  const [y,m,d] = String(str).split('-').map(Number);
-  return new Date(y, m-1, d);
+function computeDayTotals(lines) {
+  let sets = 0, volume = 0;
+  (Array.isArray(lines) ? lines : []).forEach(l => {
+    const p = parseHistoryLine(l);
+    if (p) {
+      sets++;
+      volume += p.weight * p.reps;
+    }
+  });
+  return { sets, volume };
 }
 
-function parseAiText(text, selectedDate){
-  const lines = String(text||'').split(/\r?\n/);
+// ---------- Parsing utilities ----------
+
+// AI text format
+function parseAiText(text, selectedDate) {
+  const lines = String(text || '').split(/\r?\n/);
   let target = selectedDate;
   const header = lines[0] && lines[0].match(/WORKOUT DATA - (\d{4}-\d{2}-\d{2})/i);
-  if(header) target = header[1];
-  if(!target) return null;
+  if (header) target = header[1];
+  if (!target) return null;
+
   const out = [];
   let currentExercise = null;
   lines.forEach(l => {
     const trimmed = l.trim();
-    if(!trimmed) return;
+    if (!trimmed) return;
     const exHeader = trimmed.match(/^([^:]+):\s*$/);
-    if(exHeader){
+    if (exHeader) {
       currentExercise = exHeader[1].trim();
       return;
     }
     const setMatch = trimmed.match(/^(?:Set\s+\d+\s*[-–:]?\s*)?(.*?):\s*(\d+(?:\.\d+)?)\s*(lbs|kg)\s*[×xX]\s*(\d+)\s*reps/i);
-    if(setMatch){
+    if (setMatch) {
       let name = setMatch[1].trim();
-      if(!name && currentExercise) name = currentExercise;
-      if(name){
+      if (!name && currentExercise) name = currentExercise;
+      if (name) {
         out.push(`${name}: ${setMatch[2]} ${setMatch[3]} × ${setMatch[4]} reps`);
       }
     }
   });
-  if(out.length){
-    return {[target]: out};
-  }
-  return null;
+
+  return out.length ? { [target]: out } : null;
 }
 
-function snapshotToLines(snapshot){
+// CSV format: Exercise,Set,Weight,Reps
+function parseCsv(text, selectedDate) {
+  const lines = String(text || '').trim().split(/\r?\n/);
+  if (lines.length < 2 || !selectedDate) return null;
+
+  const headers = lines[0].split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/).map(s => s.trim().toLowerCase());
+  if (!['exercise', 'set', 'weight', 'reps'].every(h => headers.includes(h))) return null;
+
+  const out = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    const parts = line.split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/).map(s => s.trim().replace(/^"|"$/g, ''));
+    if (parts.length < 4) continue;
+    const [exercise, set, weight, reps] = parts;
+    if (exercise && weight && reps) {
+      out.push(`${exercise}: Set ${set} - ${weight} lbs × ${reps} reps`);
+    }
+  }
+
+  return out.length ? { [selectedDate]: out } : null;
+}
+
+// Convert session snapshot to history lines
+function snapshotToLines(snapshot) {
   const lines = [];
-  (snapshot||[]).forEach(ex => {
-    if(ex.isSuperset){
-      ex.sets.forEach((set, setIdx) => {
-        (set.exercises||[]).forEach(sub => {
-          lines.push(`${sub.name}: Set ${setIdx+1} - ${sub.weight} lbs × ${sub.reps} reps`);
+  (snapshot || []).forEach(ex => {
+    if (ex.isSuperset) {
+      (ex.sets || []).forEach((set, idx) => {
+        (set.exercises || []).forEach(sub => {
+          lines.push(`${sub.name}: Set ${idx + 1} - ${sub.weight} lbs × ${sub.reps} reps`);
         });
       });
     } else {
-      (ex.sets||[]).forEach((set, setIdx) => {
-        lines.push(`${ex.name}: Set ${setIdx+1} - ${set.weight} lbs × ${set.reps} reps`);
+      (ex.sets || []).forEach((set, idx) => {
+        lines.push(`${ex.name}: Set ${idx + 1} - ${set.weight} lbs × ${set.reps} reps`);
       });
     }
   });
   return lines;
 }
-function computeDayTotals(lines){
-  let sets=0, volume=0;
-  (Array.isArray(lines)?lines:[]).forEach(l=>{
-    const p=parseHistoryLine(l);
-    if(p){ sets++; volume += p.weight*p.reps; }
-  });
-  return { sets, volume };
+
+// Merge new history into existing, avoiding duplicates
+function mergeHistory(base, incoming) {
+  let added = 0;
+  const dates = new Set();
+  if (!incoming) return { added, dates: [] };
+  for (const [date, lines] of Object.entries(incoming)) {
+    if (!Array.isArray(lines) || !lines.length) continue;
+    if (!base[date]) base[date] = [];
+    lines.forEach(l => {
+      if (!base[date].includes(l)) {
+        base[date].push(l);
+        added++;
+        dates.add(date);
+      }
+    });
+  }
+  return { added, dates: Array.from(dates).sort() };
 }
 
-if (typeof document !== 'undefined') {
-  document.addEventListener('DOMContentLoaded', () => {
-    // mount
-    let mount = document.getElementById('calendar') || document.getElementById('calendarRoot') || document.querySelector('section[data-role="calendar"]');
-    if(!mount){
-      mount = document.createElement('section');
-      mount.id = 'calendar';
-      const h1 = document.querySelector('h1');
-      if(h1 && h1.parentNode){ h1.insertAdjacentElement('afterend', mount); }
-      else document.body.insertBefore(mount, document.body.firstChild);
-    }
-    mount.classList.add('wt-cal');
+// ---------- UI Rendering ----------
 
-    // style
-    const style = document.createElement('style');
-    style.textContent = `
-.wt-cal{font-family:sans-serif;}
-.wt-cal .wt-cal-controls{display:flex;gap:8px;margin-bottom:8px;}
-.wt-cal-day{border:1px solid #ccc;border-radius:6px;margin-bottom:8px;}
-.wt-cal-day-header{width:100%;background:none;border:0;padding:8px;display:flex;flex-wrap:wrap;justify-content:space-between;align-items:center;text-align:left;font-size:1rem;}
-.wt-cal-day-header:focus{outline:2px solid #09f;}
-.wt-cal-chevron{transition:transform .2s ease;}
-.wt-cal-day-header[aria-expanded="false"] .wt-cal-chevron{transform:rotate(-90deg);}
-.wt-cal-day-body{padding:0 8px 8px;}
-.wt-cal-entry{display:flex;justify-content:space-between;align-items:center;padding:4px 0;}
-.wt-cal-entry .actions{display:flex;gap:4px;}
-.wt-cal-entry button{font-size:.8rem;}
-.wt-cal-add .add-row{display:flex;flex-direction:column;gap:4px;margin-top:4px;}
-.wt-cal-add input{width:100%;}
-.wt-cal-error{color:#d00;font-size:.75rem;}
-.wt-cal-live{position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;}
-`;
-    document.head.appendChild(style);
+function loadHistory() {
+  try {
+    return safeParseJson(localStorage.getItem(STORAGE_KEY)) || {};
+  } catch {
+    return {};
+  }
+}
 
-    // live region
-    const live = document.createElement('div');
-    live.className='wt-cal-live';
-    live.setAttribute('role','status');
-    live.setAttribute('aria-live','polite');
-    document.body.appendChild(live);
-    function announce(msg){ live.textContent=''; setTimeout(()=>{ live.textContent=msg; },10); }
+function saveHistory(history) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+  if (typeof renderVolumeChart === 'function') renderVolumeChart();
+}
 
-    // data
-    const STORAGE_KEY='wt_history';
-    let rawHistory={};
-    try{ rawHistory = JSON.parse(localStorage.getItem(STORAGE_KEY)) || {}; }catch(e){ rawHistory = {}; }
-    let undoSnapshot=null;
-    let saveTimer=null;
-    function scheduleSave(){
-      clearTimeout(saveTimer);
-      saveTimer = setTimeout(()=>{
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(rawHistory));
-        if (typeof renderVolumeChart === 'function') renderVolumeChart();
-      },80);
-    }
-    function getEntries(date){
-      const v = rawHistory[date];
-      return Array.isArray(v)? v.slice() : [];
-    }
+function renderCalendar(state) {
+  const cal = document.getElementById('calendar');
+  if (!cal) return;
+  cal.innerHTML = '';
 
-    // helpers
-    function formatHuman(dateStr){ return parseDateLocal(dateStr).toLocaleDateString(undefined,{weekday:'short',year:'numeric',month:'short',day:'numeric'}); }
+  // Weekday headers
+  const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  weekdays.forEach(w => {
+    const h = document.createElement('div');
+    h.className = 'cal-header';
+    h.textContent = w;
+    cal.appendChild(h);
+  });
 
-    const cards=[];
+  const month = state.currentMonth.getMonth();
+  const year = state.currentMonth.getFullYear();
+  const first = new Date(year, month, 1);
+  const start = new Date(first);
+  start.setDate(first.getDate() - first.getDay());
 
-    function offerUndo(message, snapshot){
-      undoSnapshot = snapshot;
-      if(typeof showToast === 'function'){
-        showToast(message, { actionLabel:'Undo', onAction: undo });
-        setTimeout(()=>{ undoSnapshot=null; },8000);
+  for (let i = 0; i < 42; i++) {
+    const date = new Date(start);
+    date.setDate(start.getDate() + i);
+    const dateStr = formatDate(date);
+
+    const cell = document.createElement('div');
+    cell.className = 'calendar-day';
+    cell.textContent = date.getDate();
+    cell.dataset.date = dateStr;
+
+    if (date.getMonth() !== month) cell.classList.add('muted');
+    if (state.history[dateStr] && state.history[dateStr].length) cell.classList.add('has-data');
+    if (dateStr === state.selectedDate) cell.classList.add('selected');
+
+    cell.addEventListener('click', () => {
+      state.selectedDate = dateStr;
+      renderDay(state);
+      renderCalendar(state);
+    });
+
+    cal.appendChild(cell);
+  }
+
+  const title = document.getElementById('calTitle');
+  if (title) {
+    title.textContent = state.currentMonth.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+  }
+}
+
+function renderDay(state) {
+  const title = document.getElementById('dayTitle');
+  const list = document.getElementById('entries');
+  if (!title || !list) return;
+
+  title.textContent = parseDateLocal(state.selectedDate).toDateString();
+  list.innerHTML = '';
+  const items = state.history[state.selectedDate] || [];
+
+  items.forEach((text, idx) => {
+    const li = document.createElement('li');
+    li.className = 'entry-item';
+
+    const span = document.createElement('span');
+    span.textContent = text;
+    li.appendChild(span);
+
+    const actions = document.createElement('div');
+    actions.className = 'entry-actions';
+
+    const btnEdit = document.createElement('button');
+    btnEdit.className = 'btn-mini edit';
+    btnEdit.textContent = 'Edit';
+    btnEdit.addEventListener('click', () => {
+      const val = prompt('Edit entry', text);
+      if (val == null) return; // cancelled
+      const trimmed = val.trim();
+      if (!trimmed) {
+        // remove if blank
+        items.splice(idx, 1);
       } else {
-        const bar = document.createElement('div');
-        bar.style.position='fixed';bar.style.bottom='10px';bar.style.left='50%';bar.style.transform='translateX(-50%)';
-        bar.style.background='#333';bar.style.color='#fff';bar.style.padding='8px';bar.style.borderRadius='4px';
-        const btn=document.createElement('button');btn.textContent='Undo';btn.style.marginLeft='8px';
-        btn.addEventListener('click',()=>{ undo(); document.body.removeChild(bar); });
-        bar.textContent=message; bar.appendChild(btn);
-        document.body.appendChild(bar);
-        setTimeout(()=>{ if(bar.parentNode) bar.parentNode.removeChild(bar); undoSnapshot=null; },8000);
+        items[idx] = trimmed;
       }
-    }
-    function undo(){
-      if(!undoSnapshot) return;
-      rawHistory = JSON.parse(undoSnapshot);
-      undoSnapshot=null;
-      scheduleSave();
-      renderDays();
-      announce('Undo complete.');
-    }
+      state.history[state.selectedDate] = items;
+      saveHistory(state.history);
+      renderDay(state);
+      renderCalendar(state);
+    });
 
-    document.addEventListener('keydown', e=>{
-      if((e.ctrlKey||e.metaKey) && e.key.toLowerCase()==='z'){
-        if(undoSnapshot){ e.preventDefault(); undo(); }
+    const btnDel = document.createElement('button');
+    btnDel.className = 'btn-mini del';
+    btnDel.textContent = 'Del';
+    btnDel.addEventListener('click', () => {
+      if (confirm('Delete entry?')) {
+        items.splice(idx, 1);
+        state.history[state.selectedDate] = items;
+        saveHistory(state.history);
+        renderDay(state);
+        renderCalendar(state);
       }
     });
 
-    // controls
-    mount.innerHTML='';
-    const controls = document.createElement('div');
-    controls.className='wt-cal-controls';
-    const expandAll = document.createElement('button');
-    expandAll.type='button'; expandAll.textContent='Expand All';
-    const collapseAll = document.createElement('button');
-    collapseAll.type='button'; collapseAll.textContent='Collapse All';
-    controls.appendChild(expandAll); controls.appendChild(collapseAll);
-    mount.appendChild(controls);
+    actions.appendChild(btnEdit);
+    actions.appendChild(btnDel);
+    li.appendChild(actions);
+    list.appendChild(li);
+  });
 
-    const container = document.createElement('div');
-    mount.appendChild(container);
+  const resetBtn = document.getElementById('resetDay');
+  if (resetBtn) {
+    resetBtn.disabled = items.length === 0;
+  }
+}
 
-    expandAll.addEventListener('click', ()=>{
-      cards.forEach(c=>{ c.header.setAttribute('aria-expanded','true'); c.body.style.display=''; c.build(true); });
-    });
-    collapseAll.addEventListener('click', ()=>{
-      cards.forEach(c=>{ c.header.setAttribute('aria-expanded','false'); c.body.style.display='none'; });
-    });
+function initCalendar() {
+  if (typeof document === 'undefined') return;
+  document.addEventListener('DOMContentLoaded', () => {
+    const state = {
+      history: loadHistory(),
+      currentMonth: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+      selectedDate: formatDate(new Date())
+    };
 
-    function renderDays(){
-      container.innerHTML='';
-      cards.length=0;
-      const dates = Object.keys(rawHistory).sort((a,b)=>b.localeCompare(a)).slice(0,90);
-      if(dates.length===0){
-        container.textContent='No history';
-        if (typeof renderVolumeChart === 'function') renderVolumeChart();
-        return;
-      }
-      dates.forEach((date, idx)=>{
-        const card = createDayCard(date, idx<7, idx<14);
-        container.appendChild(card.el);
-        cards.push(card);
+    // Navigation
+    const prev = document.getElementById('calPrev');
+    const next = document.getElementById('calNext');
+    const todayBtn = document.getElementById('calToday');
+    const gotoInput = document.getElementById('calGoto');
+    const gotoBtn = document.getElementById('calGo');
+
+    if (prev) prev.addEventListener('click', () => { state.currentMonth.setMonth(state.currentMonth.getMonth() - 1); renderCalendar(state); });
+    if (next) next.addEventListener('click', () => { state.currentMonth.setMonth(state.currentMonth.getMonth() + 1); renderCalendar(state); });
+    if (todayBtn) todayBtn.addEventListener('click', () => { const today = new Date(); state.currentMonth = new Date(today.getFullYear(), today.getMonth(), 1); state.selectedDate = formatDate(today); renderCalendar(state); renderDay(state); });
+    if (gotoInput && gotoBtn) {
+      gotoInput.addEventListener('input', () => { gotoBtn.disabled = !gotoInput.value; });
+      gotoBtn.addEventListener('click', () => {
+        const d = parseDateLocal(gotoInput.value);
+        if (isNaN(d)) return;
+        state.currentMonth = new Date(d.getFullYear(), d.getMonth(), 1);
+        state.selectedDate = formatDate(d);
+        renderCalendar(state);
+        renderDay(state);
       });
-      if (typeof renderVolumeChart === 'function') renderVolumeChart();
     }
 
-    function createDayCard(date, expandedDefault, buildNow){
-      const cardEl = document.createElement('div'); cardEl.className='wt-cal-day';
-      const header = document.createElement('button');
-      header.type='button';
-      header.className='wt-cal-day-header';
-      header.setAttribute('aria-expanded', expandedDefault? 'true':'false');
-      const dateSpan=document.createElement('span'); dateSpan.textContent=formatHuman(date);
-      const totalsSpan=document.createElement('span'); totalsSpan.className='wt-cal-totals';
-      const chev=document.createElement('span'); chev.className='wt-cal-chevron'; chev.textContent='▾';
-      header.appendChild(dateSpan); header.appendChild(totalsSpan); header.appendChild(chev);
-      cardEl.appendChild(header);
-      const body=document.createElement('div'); body.className='wt-cal-day-body';
-      if(!expandedDefault) body.style.display='none';
-      cardEl.appendChild(body);
-
-      function refreshTotals(){
-        const t = computeDayTotals(getEntries(date));
-        totalsSpan.textContent = `Sets: ${t.sets} • Volume: ${t.volume} lbs`;
-      }
-
-      let built=false;
-      function build(force=false){
-        if(built && !force) return;
-        body.innerHTML='';
-        const ul=document.createElement('ul');
-        getEntries(date).forEach((line,i)=>{ ul.appendChild(createEntry(date,line,i)); });
-        body.appendChild(ul);
-        body.appendChild(createAddRow(date));
-        built=true;
-      }
-
-      if(expandedDefault && buildNow) build();
-
-      header.addEventListener('click', ()=>{
-         const exp = header.getAttribute('aria-expanded')==='true';
-         header.setAttribute('aria-expanded', exp? 'false':'true');
-         if(exp){ body.style.display='none'; }
-         else { body.style.display=''; build(); }
+    // Entry add
+    const addBtn = document.getElementById('addEntry');
+    const entryInput = document.getElementById('entryInput');
+    if (addBtn && entryInput) {
+      addBtn.addEventListener('click', () => {
+        const val = entryInput.value.trim();
+        if (!val) return;
+        if (!state.history[state.selectedDate]) state.history[state.selectedDate] = [];
+        state.history[state.selectedDate].push(val);
+        entryInput.value = '';
+        saveHistory(state.history);
+        renderDay(state);
+        renderCalendar(state);
       });
+    }
 
-      const card={ el:cardEl, header, body, build, refreshTotals };
-      refreshTotals();
-      return card;
-
-      function createEntry(date,line,index){
-        const li=document.createElement('li'); li.className='wt-cal-entry';
-        const span=document.createElement('span'); span.textContent=line; li.appendChild(span);
-        const actions=document.createElement('span'); actions.className='actions'; li.appendChild(actions);
-        const edit=document.createElement('button'); edit.type='button'; edit.textContent='Edit'; edit.setAttribute('aria-label','Edit entry'); actions.appendChild(edit);
-        const del=document.createElement('button'); del.type='button'; del.textContent='Del'; del.setAttribute('aria-label','Delete entry'); actions.appendChild(del);
-
-        edit.addEventListener('click', ()=>enterEdit());
-        del.addEventListener('click', ()=>{
-          const prev = JSON.stringify(rawHistory);
-          const arr = getEntries(date);
-          arr.splice(index,1);
-          if(arr.length) rawHistory[date]=arr; else delete rawHistory[date];
-          scheduleSave();
-          announce('Deleted entry.');
-          offerUndo('Entry deleted', prev);
-          build(true);
-          refreshTotals();
-        });
-
-        function enterEdit(){
-          const input=document.createElement('input'); input.type='text'; input.value=line;
-          input.className='wt-cal-edit';
-          li.insertBefore(input, span); li.removeChild(span);
-          edit.style.display='none';
-          const err=document.createElement('div'); err.className='wt-cal-error'; li.appendChild(err);
-          input.focus();
-          function save(){
-            const val=input.value.trim();
-            if(!val){ err.textContent='Required'; return; }
-            const parsed=parseHistoryLine(val);
-            if(!parsed){
-              err.textContent='Invalid format';
-              if(!confirm('Invalid format. Keep as free text?')) return;
-            }
-            const prev = JSON.stringify(rawHistory);
-            const arr = getEntries(date);
-            arr[index]=val;
-            rawHistory[date]=arr;
-            scheduleSave();
-            announce('Edited entry on '+formatHuman(date)+'.');
-            offerUndo('Entry updated', prev);
-            build(true);
-            refreshTotals();
-          }
-          function cancel(){ err.remove(); build(true); }
-          input.addEventListener('keydown', e=>{
-            if(e.key==='Enter'){ e.preventDefault(); save(); }
-            else if(e.key==='Escape'){ e.preventDefault(); cancel(); }
-          });
+    // Reset day
+    const resetBtn = document.getElementById('resetDay');
+    if (resetBtn) {
+      resetBtn.addEventListener('click', () => {
+        if (confirm('Clear all entries for this day?')) {
+          delete state.history[state.selectedDate];
+          saveHistory(state.history);
+          renderDay(state);
+          renderCalendar(state);
         }
-
-        return li;
-      }
-
-      function createAddRow(date){
-        const wrap=document.createElement('div'); wrap.className='wt-cal-add';
-        const btn=document.createElement('button'); btn.type='button'; btn.textContent='+ Add'; wrap.appendChild(btn);
-        let row=null;
-        btn.addEventListener('click', ()=>{
-          if(row) return;
-          btn.style.display='none';
-          row=document.createElement('div'); row.className='add-row';
-          const input=document.createElement('input'); input.type='text'; input.placeholder='Exercise: 100 lbs × 5 reps';
-          const err=document.createElement('div'); err.className='wt-cal-error';
-          row.appendChild(input); row.appendChild(err); wrap.appendChild(row); input.focus();
-          function save(){
-            const val=input.value.trim();
-            if(!val){ err.textContent='Required'; return; }
-            const parsed=parseHistoryLine(val);
-            if(!parsed){
-              err.textContent='Invalid format';
-              if(!confirm('Invalid format. Keep as free text?')) return;
-            }
-            const prev = JSON.stringify(rawHistory);
-            const arr=getEntries(date);
-            arr.push(val);
-            rawHistory[date]=arr;
-            scheduleSave();
-            announce('Added entry.');
-            offerUndo('Entry added', prev);
-            build(true);
-            refreshTotals();
-            row.remove(); row=null; btn.style.display='';
-            setTimeout(()=>{
-              const items=body.querySelectorAll('li');
-              if(items.length) items[items.length-1].scrollIntoView({behavior:'smooth',block:'center'});
-            },50);
-          }
-          function cancel(){ row.remove(); row=null; btn.style.display=''; }
-          input.addEventListener('keydown', e=>{
-            if(e.key==='Enter'){ e.preventDefault(); save(); }
-            else if(e.key==='Escape'){ e.preventDefault(); cancel(); }
-          });
-        });
-        return wrap;
-      }
+      });
     }
 
-    renderDays();
+    // Export
+    const exportBtn = document.getElementById('exportHistory');
+    if (exportBtn) {
+      exportBtn.addEventListener('click', () => {
+        const blob = new Blob([JSON.stringify(state.history, null, 2)], { type: 'application/json' });
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = 'history.json';
+        a.click();
+        URL.revokeObjectURL(a.href);
+      });
+    }
+
+    // Import from file
+    const importBtn = document.getElementById('importHistory');
+    const importFile = document.getElementById('importHistoryFile');
+    if (importBtn && importFile) {
+      importBtn.addEventListener('click', () => importFile.click());
+      importFile.addEventListener('change', () => {
+        const file = importFile.files && importFile.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+          const data = safeParseJson(reader.result);
+          const res = mergeHistory(state.history, data);
+          if (res.added) {
+            saveHistory(state.history);
+            alert(`Imported ${res.added} entries for ${res.dates.length} days`);
+            state.selectedDate = res.dates[0] || state.selectedDate;
+            renderCalendar(state);
+            renderDay(state);
+          } else {
+            alert('No new entries imported');
+          }
+        };
+        reader.readAsText(file);
+        importFile.value = '';
+      });
+    }
+
+    // Import from paste
+    const pasteArea = document.getElementById('pasteJson');
+    const pasteBtn = document.getElementById('importFromPaste');
+    if (pasteArea && pasteBtn) {
+      pasteBtn.addEventListener('click', () => {
+        const txt = pasteArea.value;
+        let data = extractJsonFromText(txt);
+        if (!data) data = parseAiText(txt, state.selectedDate);
+        if (!data) data = parseCsv(txt, state.selectedDate);
+        if (!data) { alert('Invalid data'); return; }
+        const res = mergeHistory(state.history, data);
+        if (res.added) {
+          saveHistory(state.history);
+          alert(`Imported ${res.added} entries for ${res.dates.length} days`);
+          state.selectedDate = res.dates[0] || state.selectedDate;
+          pasteArea.value = '';
+          renderCalendar(state);
+          renderDay(state);
+        } else {
+          alert('No new entries imported');
+        }
+      });
+    }
+
+    // Save today session
+    const saveSessionBtn = document.getElementById('saveTodaySession');
+    if (saveSessionBtn) {
+      saveSessionBtn.addEventListener('click', () => {
+        if (typeof window.getSessionSnapshot !== 'function') {
+          alert('No session snapshot available');
+          return;
+        }
+        const snap = window.getSessionSnapshot();
+        const lines = snapshotToLines(snap);
+        const data = { [state.selectedDate]: lines };
+        const res = mergeHistory(state.history, data);
+        if (res.added) {
+          saveHistory(state.history);
+          alert(`Saved ${res.added} entries for today`);
+          renderCalendar(state);
+          renderDay(state);
+        } else {
+          alert('No new entries to save');
+        }
+      });
+    }
+
+    renderCalendar(state);
+    renderDay(state);
   });
 }
 
-// for tests
-if(typeof module !== 'undefined'){ module.exports = { parseHistoryLine, computeDayTotals, parseDateLocal, parseAiText, snapshotToLines }; }
+initCalendar();
+
+// ---------- Exports for Node ----------
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    parseDateLocal,
+    parseAiText,
+    parseCsv,
+    snapshotToLines,
+    mergeHistory,
+    parseHistoryLine,
+    computeDayTotals,
+  };
+}
+

--- a/tests/calendar.test.js
+++ b/tests/calendar.test.js
@@ -1,4 +1,4 @@
-const { parseDateLocal, parseAiText, snapshotToLines } = require('../calendar');
+const { parseDateLocal, parseAiText, parseCsv, snapshotToLines, mergeHistory } = require('../calendar');
 
 test('parseDateLocal returns exact date', () => {
   const d = parseDateLocal('2025-08-01');
@@ -19,6 +19,17 @@ test('parseAiText parses exported AI text format', () => {
   });
 });
 
+test('parseAiText handles inline exercise lines', () => {
+  const sample = `WORKOUT DATA - 2024-07-04\nSet 1 - Bench Press: 185 lbs × 5 reps\nSet 1 - Squat: 225 lbs × 5 reps`;
+  const res = parseAiText(sample, '2024-07-04');
+  expect(res).toEqual({
+    '2024-07-04': [
+      'Bench Press: 185 lbs × 5 reps',
+      'Squat: 225 lbs × 5 reps'
+    ]
+  });
+});
+
 test('parseAiText preserves weight units', () => {
   const sample = `WORKOUT DATA - 2024-07-04\n\nSquat:\n  Set 1: 100 kg × 5 reps`;
   const res = parseAiText(sample, '2024-07-04');
@@ -28,6 +39,23 @@ test('parseAiText preserves weight units', () => {
 test('parseAiText returns null without date', () => {
   const sample = `Bench Press:\n  Set 1: 185 lbs × 5 reps`;
   expect(parseAiText(sample)).toBeNull();
+});
+
+test('parseCsv happy path', () => {
+  const csv = `Exercise,Set,Weight,Reps\nBench Press,1,185,5\nBench Press,2,185,5\nSquat,1,225,5`;
+  const res = parseCsv(csv, '2024-07-04');
+  expect(res).toEqual({
+    '2024-07-04': [
+      'Bench Press: Set 1 - 185 lbs × 5 reps',
+      'Bench Press: Set 2 - 185 lbs × 5 reps',
+      'Squat: Set 1 - 225 lbs × 5 reps'
+    ]
+  });
+});
+
+test('parseCsv invalid headers', () => {
+  const csv = `Ex,Set,Weight,Reps\nBench,1,100,10`;
+  expect(parseCsv(csv, '2024-07-04')).toBeNull();
 });
 
 test('snapshotToLines retains duplicate sets with numbering', () => {
@@ -47,4 +75,34 @@ test('snapshotToLines retains duplicate sets with numbering', () => {
     'Bench Press: Set 1 - 185 lbs × 5 reps',
     'Bench Press: Set 2 - 185 lbs × 5 reps'
   ]);
+});
+
+test('snapshotToLines expands supersets', () => {
+  const snapshot = [
+    {
+      name: 'Superset',
+      isSuperset: true,
+      sets: [
+        { exercises: [ { name: 'Bench', weight: 100, reps: 5 }, { name: 'Row', weight: 80, reps: 8 } ] },
+        { exercises: [ { name: 'Bench', weight: 100, reps: 5 }, { name: 'Row', weight: 80, reps: 8 } ] }
+      ]
+    }
+  ];
+  const lines = snapshotToLines(snapshot);
+  expect(lines).toEqual([
+    'Bench: Set 1 - 100 lbs × 5 reps',
+    'Row: Set 1 - 80 lbs × 8 reps',
+    'Bench: Set 2 - 100 lbs × 5 reps',
+    'Row: Set 2 - 80 lbs × 8 reps'
+  ]);
+});
+
+test('mergeHistory avoids duplicates', () => {
+  const base = { '2024-07-04': ['Bench: 100 lbs × 5 reps'] };
+  const incoming = { '2024-07-04': ['Bench: 100 lbs × 5 reps', 'Squat: 200 lbs × 5 reps'], '2024-07-05': ['Row: 80 lbs × 8 reps'] };
+  mergeHistory(base, incoming);
+  expect(base).toEqual({
+    '2024-07-04': ['Bench: 100 lbs × 5 reps', 'Squat: 200 lbs × 5 reps'],
+    '2024-07-05': ['Row: 80 lbs × 8 reps']
+  });
 });


### PR DESCRIPTION
## Summary
- rebuild calendar.js with classic month grid, entry management, CSV/AI/JSON import helpers and mergeHistory
- expand calendar tests for AI text, CSV, superset snapshots and merge dedupe
- add core helpers in script.js to satisfy tests and provide storage utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae81c143e483328ad2844cf4c05647