### PR TITLE
Improve mobile editing for workout notes

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -204,15 +204,40 @@ if (typeof document !== 'undefined') {
         editBtn.textContent = 'Edit';
         editBtn.className = 'btn-mini edit';
         editBtn.addEventListener('click', () => {
-          const updated = prompt('Edit entry', text);
-          if(updated !== null){
-            history[selectedDate][idx] = updated.trim();
-            if(!history[selectedDate][idx]) history[selectedDate].splice(idx,1);
-            if(history[selectedDate].length === 0) delete history[selectedDate];
-            save();
-            renderDay();
-            renderCalendar();
-          }
+          if (li.querySelector('.edit-form')) return;
+          const form = document.createElement('div');
+          form.className = 'edit-form';
+          form.innerHTML = `
+            <div class="row">
+              <input type="text" class="editEntryInput" value="${text}">
+            </div>
+            <div class="row2">
+              <button type="button" class="btn-mini edit" data-action="save">Save</button>
+              <button type="button" class="btn-mini del" data-action="cancel">Cancel</button>
+            </div>
+          `;
+          li.appendChild(form);
+          const input = form.querySelector('.editEntryInput');
+          input.focus();
+          form.addEventListener('click', ev => {
+            const action = ev.target.getAttribute('data-action');
+            if (action === 'save') {
+              const updated = input.value.trim();
+              if (updated) {
+                history[selectedDate][idx] = updated;
+              } else {
+                history[selectedDate].splice(idx,1);
+                if (history[selectedDate].length === 0) delete history[selectedDate];
+              }
+              save();
+              renderDay();
+              renderCalendar();
+            }
+            if (action === 'cancel') {
+              form.remove();
+              editBtn.focus();
+            }
+          });
         });
         actions.appendChild(editBtn);
 

--- a/style.css
+++ b/style.css
@@ -229,7 +229,7 @@ body.dark #calendarSection{
 .day-details{border:1px solid #e6eaef;border-radius:8px;padding:10px;margin-bottom:12px;}
 .day-details h4{margin-bottom:8px;}
 .day-details ul{list-style:disc;margin-left:20px;margin-bottom:8px;}
-.entry-item{display:flex;justify-content:space-between;align-items:center;gap:6px;margin-bottom:4px;}
+.entry-item{display:flex;justify-content:space-between;align-items:center;gap:6px;margin-bottom:4px;flex-wrap:wrap;}
 .entry-item span{flex:1;}
 .entry-actions{display:flex;gap:6px;}
 .history-actions{display:flex;gap:8px;flex-wrap:wrap;}


### PR DESCRIPTION
## Summary
- Replace prompt-based workout note editing with inline form and save/cancel actions
- Allow entry items to wrap so edit form displays correctly on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7ed16e688332bff1dcb5baa09c6b