### PR TITLE
Lock next workouts to current session exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ These guardrails apply when logging, editing, merging current exercise into sess
 
 - JSON: `workout_YYYY-MM-DD.json` includes the normalized session plus context fields:
   - Core fields: `date`, `timestamp`, `totalExercises`, `totalSets`, `exercises[]`, `schema` (currently `8`).
-  - Optional extras saved when provided: `session{ sessionStart, sessionEnd, sessionDurationSec }`, `workoutNotes[]`, `goals[]`, `constraints`, and `exerciseHighlights`.
+  - Optional extras saved when provided: `session{ sessionStart, sessionEnd, sessionDurationSec }`, `workoutNotes[]`, `goals[]`, `constraints`, `exerciseHighlights`, and `exerciseSelection{ source, currentExercises[], requiredExercises[] }`.
 - CSV: header `Exercise,Set,Weight,Reps,Distance,Duration,Time,RestPlanned(sec),RestActual(sec)`. If session time is included, metadata rows are prepended.
-- AI Text: structured summary with session snapshot, goals, constraints, exercise highlights (including PR flags/trends), optional freeform notes, and an optional “Progression Guard” directive to prevent stagnation (tells the AI to use prior workouts in the same chat plus today’s log). When enabled, the export includes per-exercise progression metrics and auto “next targets” for every lift logged. Time-limited exports also recover the best-matching recent exercise roster so the AI must display the complete next workout while keeping a clear priority stopping point.
+- AI Text: structured summary with session snapshot, goals, constraints, exercise highlights (including PR flags/trends), optional freeform notes, and an optional “Progression Guard” directive to prevent stagnation. Historical workouts may guide progression calculations only; the current exported session exclusively controls which exercises appear in the next workout. Time limits may change priority and the stopping point, but never add exercises from another workout day.
 
 ## Context Panels
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         <div class="brand-copy">
           <div class="brand-row">
             <div class="header-kicker">Train • Track • Progress</div>
-            <span class="version-badge">v1.6</span>
+            <span class="version-badge">v1.7</span>
             <button id="themePackButton" class="theme-pack-trigger" type="button" aria-haspopup="dialog" aria-controls="themePackSheet" aria-label="Choose visual theme">
               <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a9 9 0 1 0 0 18h1.2a1.8 1.8 0 0 0 0-3.6h-.8a1.6 1.6 0 0 1 0-3.2H15A6 6 0 0 0 21 8.3C19.5 5.1 16.1 3 12 3Z"/><circle cx="7.5" cy="10" r="1"/><circle cx="10" cy="6.8" r="1"/><circle cx="15" cy="7" r="1"/></svg>
               <span id="themePackLabel">Aurora</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workout-tracker",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workout-tracker",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "devDependencies": {
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workout-tracker",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "scripts": {
     "setup": "npm install",
     "test": "jest",

--- a/script.js
+++ b/script.js
@@ -1565,14 +1565,14 @@ function getWorkoutExerciseRoster(payload) {
 
   (payload?.exercises || []).forEach((exercise) => {
     if (!exercise) return;
+    const loggedSets = Array.isArray(exercise.sets) ? exercise.sets : [];
+    if (!loggedSets.length) return;
     if (exercise.isSuperset) {
-      (exercise.exercises || []).forEach(addName);
-      (exercise.sets || []).forEach((set) => {
+      const countBefore = names.length;
+      loggedSets.forEach((set) => {
         (set.exercises || []).forEach((inner) => addName(inner?.name));
       });
-      if (!(exercise.exercises || []).length && !(exercise.sets || []).length) {
-        addName(exercise.name);
-      }
+      if (names.length === countBefore) (exercise.exercises || []).forEach(addName);
       return;
     }
     addName(exercise.name);
@@ -1581,106 +1581,13 @@ function getWorkoutExerciseRoster(payload) {
   return names;
 }
 
-function buildWorkoutCoverageReference(currentPayload, previousSessions = []) {
+function buildExerciseSelectionReference(currentPayload) {
   const currentExercises = getWorkoutExerciseRoster(currentPayload);
-  const currentKeys = new Set(currentExercises.map(exerciseGoalKey));
-  let bestMatch = null;
-
-  (Array.isArray(previousSessions) ? previousSessions : []).forEach((session, index) => {
-    const exercises = getWorkoutExerciseRoster(session);
-    if (!exercises.length) return;
-    const exerciseKeys = new Set(exercises.map(exerciseGoalKey));
-    const overlapCount = [...exerciseKeys].filter((key) => currentKeys.has(key)).length;
-    if (!overlapCount) return;
-    const unionCount = new Set([...currentKeys, ...exerciseKeys]).size || 1;
-    const similarity = overlapCount / unionCount;
-    const candidate = {
-      date: session?.date || null,
-      exercises,
-      session,
-      overlapCount,
-      similarity,
-      index,
-    };
-    if (
-      !bestMatch
-      || candidate.overlapCount > bestMatch.overlapCount
-      || (
-        candidate.overlapCount === bestMatch.overlapCount
-        && candidate.similarity > bestMatch.similarity
-      )
-      || (
-        candidate.overlapCount === bestMatch.overlapCount
-        && candidate.similarity === bestMatch.similarity
-        && candidate.index < bestMatch.index
-      )
-    ) {
-      bestMatch = candidate;
-    }
-  });
-
-  const comparableExercises = bestMatch?.exercises || [];
-  const requiredExercises = [...currentExercises];
-  const requiredKeys = new Set(requiredExercises.map(exerciseGoalKey));
-  comparableExercises.forEach((name) => {
-    const key = exerciseGoalKey(name);
-    if (requiredKeys.has(key)) return;
-    requiredKeys.add(key);
-    requiredExercises.push(name);
-  });
-  const possiblyOmittedExercises = comparableExercises.filter(
-    (name) => !currentKeys.has(exerciseGoalKey(name)),
-  );
-
   return {
+    source: 'current_session_only',
     currentExercises,
-    comparableDate: bestMatch?.date || null,
-    comparableExercises,
-    requiredExercises,
-    possiblyOmittedExercises,
-    comparableSession: bestMatch?.session || null,
+    requiredExercises: [...currentExercises],
   };
-}
-
-function getCoverageSetSummaries(payload, exerciseName) {
-  const targetKey = exerciseGoalKey(exerciseName);
-  const summaries = [];
-  const addStrengthSet = (set, weight, reps) => {
-    const normalized = normalizeSet({ ...set, weight, reps, exercises: undefined });
-    if (normalizeSetRole(normalized.role) === 'failed_attempt' || normalized.completed === false) {
-      summaries.push(`failed attempt at ${formatGoalNumber(normalized.weight)} lbs`);
-      return;
-    }
-    summaries.push(`${formatGoalNumber(normalized.weight)} lbs × ${formatGoalNumber(normalized.reps)}`);
-  };
-
-  (payload?.exercises || []).forEach((exercise) => {
-    if (!exercise) return;
-    if (exercise.isSuperset) {
-      (exercise.sets || []).forEach((set) => {
-        (set.exercises || []).forEach((inner) => {
-          if (exerciseGoalKey(inner?.name) === targetKey) {
-            addStrengthSet(set, inner.weight, inner.reps);
-          }
-        });
-      });
-      return;
-    }
-    if (exerciseGoalKey(exercise.name) !== targetKey) return;
-    if (exercise.isCardio) {
-      (exercise.sets || []).forEach((set) => {
-        const distance = Number(set.distance);
-        const distanceText = Number.isFinite(distance) && distance > 0
-          ? `${formatGoalNumber(distance)} mi in `
-          : '';
-        summaries.push(`${distanceText}${formatSecondsHuman(set.duration)}`);
-      });
-      return;
-    }
-    (exercise.sets || []).forEach((set) => addStrengthSet(set, set.weight, set.reps));
-  });
-
-  return summaries;
 }
 
 function computeConsistencyMetricsFromStats(allStats, referenceDate) {
@@ -5088,14 +4995,8 @@ if (typeof document !== "undefined" && document.getElementById("today")) {
     else if (dayCompare === '3') previousSessions = previousSessions.slice(0, 3);
     else if (dayCompare === '7') previousSessions = previousSessions.slice(0, 7);
 
-    const workoutCoverage = buildWorkoutCoverageReference(payload, previousSessions);
-    payload.workoutCoverage = {
-      currentExercises: workoutCoverage.currentExercises,
-      comparableDate: workoutCoverage.comparableDate,
-      comparableExercises: workoutCoverage.comparableExercises,
-      requiredExercises: workoutCoverage.requiredExercises,
-      possiblyOmittedExercises: workoutCoverage.possiblyOmittedExercises,
-    };
+    const exerciseSelection = buildExerciseSelectionReference(payload);
+    payload.exerciseSelection = exerciseSelection;
 
     const currentStats = computeSessionStats(payload);
     const previousStats = previousSessions.map((session) =>
@@ -5287,14 +5188,14 @@ if (typeof document !== "undefined" && document.getElementById("today")) {
     aiText += `AUTOMATIC COACHING CONTRACT\n`;
     aiText += `- The user has chosen a long-term result and should not have to design the next workout. Do the progression calculations for them.\n`;
     aiText += `- Put a short DO THIS NEXT section first. Give one primary prescription, not a menu of programs or choices.\n`;
-    aiText += `- Always show the complete next-workout exercise list. A time limit may change priority and the stopping point, but it must never make the remaining planned exercises disappear from the response.\n`;
+    aiText += `- The current exported session is the only source of exercise selection. Include every current-session exercise and do not add exercises from history, another workout day, or earlier AI recommendations.\n`;
     aiText += `- Keep the long-term goal fixed, update the next step from completed evidence after every export, and show the load/repetition/set percentage change used.\n`;
     aiText += `- The user should only need to follow the prescription, log what happened, and export again. Reserve alternatives for pain, unavailable equipment, or a red-readiness safety rule.\n\n`;
 
     aiText += `SESSION COMPLETION & NEXT-WORKOUT BUDGET\n`;
     aiText += `- Current session status: ${payload.sessionContext.statusLabel}\n`;
     if (payload.sessionContext.status === 'time_limited') {
-      aiText += `- Interpretation: Omitted exercises and lower total volume are not regressions. Preserve the complete next-workout exercise list, put the highest priorities first, identify a safe stopping point, and do not add catch-up sets.\n`;
+      aiText += `- Interpretation: Omitted exercises and lower total volume are not regressions. Prescribe every exercise actually logged in this export, but do not recover or add exercises from older workouts merely because time ran out. Put the current-session exercises in priority order and do not add catch-up sets.\n`;
     } else if (payload.sessionContext.status === 'pain_limited') {
       aiText += `- Interpretation: Do not progress or re-prescribe painful movements without a pain-free alternative and an appropriate stop rule.\n`;
     } else if (payload.sessionContext.status === 'recovery_limited') {
@@ -5304,41 +5205,18 @@ if (typeof document !== "undefined" && document.getElementById("today")) {
     }
     if (payload.sessionContext.nextWorkoutMinutes != null) {
       aiText += `- Hard time budget for the next workout: ${payload.sessionContext.nextWorkoutMinutes} minutes, including warm-ups and rest.\n`;
-      aiText += `- MUST DO FIRST duration target: at most ${payload.sessionContext.mustDoTargetMinutes} minutes, leaving ${payload.sessionContext.timeBufferMinutes} minutes for normal setup and transition uncertainty. Still display every remaining prescribed exercise afterward under CONTINUE IF TIME, with its exact sets, reps, load, rest, and normal per-exercise dose.\n`;
+      aiText += `- MUST DO FIRST duration target: at most ${payload.sessionContext.mustDoTargetMinutes} minutes, leaving ${payload.sessionContext.timeBufferMinutes} minutes for normal setup and transition uncertainty. Still display every remaining current-session exercise afterward under CONTINUE IF TIME, with its exact sets, reps, load, rest, and normal per-exercise dose.\n`;
     } else {
-      aiText += `- Next-workout time budget: Not provided. Show the complete workout and its full estimated duration. Do not shrink or omit the exercise list merely because this session ran out of time; use priority order and a safe stopping point instead. Do not exceed the latest completed comparable session's normal per-exercise workload without a specific recovery-based reason.\n`;
+      aiText += `- Next-workout time budget: Not provided. Show the complete current-session exercise list and its full estimated duration. Do not omit a current-session exercise merely because this session ran out of time, and do not add an exercise from history. Do not exceed the latest completed comparable session's normal per-exercise workload without a specific recovery-based reason.\n`;
     }
     aiText += `\n`;
 
-    aiText += `FULL NEXT-WORKOUT COVERAGE (MANDATORY)\n`;
-    aiText += `- Exercises logged today: ${workoutCoverage.currentExercises.length ? workoutCoverage.currentExercises.join('; ') : 'None'}\n`;
-    if (workoutCoverage.comparableDate && workoutCoverage.comparableExercises.length) {
-      aiText += `- Best matching recent workout roster (${workoutCoverage.comparableDate}): ${workoutCoverage.comparableExercises.join('; ')}\n`;
-    } else {
-      aiText += `- Best matching recent workout roster: Not available in the selected history.\n`;
-    }
-    if (workoutCoverage.possiblyOmittedExercises.length) {
-      aiText += `- Exercises possibly omitted only because time ran out: ${workoutCoverage.possiblyOmittedExercises.join('; ')}\n`;
-      aiText += `- Last comparable evidence for those exercises:\n`;
-      workoutCoverage.possiblyOmittedExercises.forEach((name) => {
-        const summaries = getCoverageSetSummaries(workoutCoverage.comparableSession, name);
-        const key = exerciseGoalKey(name);
-        const savedGoal = exerciseGoals[key] || null;
-        const savedProfile = normalizeExerciseProfile(exerciseProfiles[key]);
-        const resolvedProfile = savedProfile.mode === 'auto'
-          ? buildAutomaticExerciseProfile(name, savedGoal, savedProfile)
-          : savedProfile;
-        const goalText = savedGoal
-          ? ` Saved goal: ${formatGoalNumber(savedGoal.goalValue)} ${savedGoal.unit} (${savedGoal.goalPathLabel}).`
-          : ' No saved goal was found.';
-        aiText += `  ${name}: ${summaries.length ? summaries.join(', ') : 'No usable set details found'}.${goalText} Coaching target: ${resolvedProfile.repMin}–${resolvedProfile.repMax} reps with about ${formatGoalNumber(resolvedProfile.targetRir)} clean reps left; smallest load jump ${formatGoalNumber(resolvedProfile.loadStep)} lbs.\n`;
-      });
-    } else {
-      aiText += `- Exercises possibly omitted only because time ran out: None found in the selected comparable history.\n`;
-    }
-    aiText += `- Required coverage roster: ${workoutCoverage.requiredExercises.length ? workoutCoverage.requiredExercises.join('; ') : 'No exercises available'}\n`;
-    aiText += `- Every exercise in the required coverage roster must appear in the response with an exact prescription. If an exercise is intentionally removed or replaced for pain, safety, a changed goal, or equipment availability, list it explicitly and explain why; never silently omit it.\n`;
-    aiText += `- Time affects priority, not visibility: put the time-fitting portion under MUST DO FIRST, then show every remaining prescribed exercise under CONTINUE IF TIME in the order it should be performed. These remaining exercises are still part of the complete workout.\n`;
+    aiText += `CURRENT-SESSION EXERCISE SELECTION (MANDATORY)\n`;
+    aiText += `- Required exercise list from this export: ${exerciseSelection.requiredExercises.length ? exerciseSelection.requiredExercises.join('; ') : 'No exercises available'}\n`;
+    aiText += `- Historical data controls progression only. It may change the next weight, repetitions, sets, rest, or progression decision for a current-session exercise, but it must never add an exercise that is absent from this export.\n`;
+    aiText += `- Include every exercise in the required current-session list and include no other exercise. Do not combine exercises from different workout days, older exports, other conversations, or previous AI recommendations.\n`;
+    aiText += `- An exercise may be added, removed, or replaced only when the user explicitly requests it, this export explicitly requests a change, a completed goal has a saved next-step instruction, or pain, safety, or unavailable equipment requires a substitution. Label every permitted substitution and explain why.\n`;
+    aiText += `- Time affects priority, not the required current-session list: put the time-fitting portion under MUST DO FIRST, then show every other current-session exercise under CONTINUE IF TIME with exact instructions.\n`;
     aiText += `- Do not turn missed work into catch-up volume. Give each exercise only its normal evidence-based dose.\n\n`;
 
     aiText += `SESSION GOALS & FOCUS\n`;
@@ -5509,12 +5387,12 @@ if (typeof document !== "undefined" && document.getElementById("today")) {
     aiText += `NEXT STEPS REQUEST\n`;
     aiText += `Analyze the session and produce one ready-to-follow next workout. Start with DO THIS NEXT. The user must not need to understand programming language or make training decisions mid-session.\n`;
     aiText += `1. Insight: Distinguish evidence from inference. Note trends, weak points, and possible fatigue signals without treating mechanical volume or a single session as proof.\n`;
-    aiText += `2. Exact full workout: List every exercise in the Required coverage roster in order. Separate warm-up sets from work sets and give exact sets × reps, exact load when equipment permits, rest time, a plain-language effort target such as “stop with 2 clean reps left,” and one concise technique cue. State warm-up sets, work sets, total logged sets, the MUST DO FIRST stopping point, and realistic durations for both the priority portion and the complete workout.\n`;
+    aiText += `2. Exact full workout: List every exercise in the Required current-session exercise list in order, and do not list any exercise outside it unless a permitted substitution is explicitly labeled. Separate warm-up sets from work sets and give exact sets × reps, exact load when equipment permits, rest time, a plain-language effort target such as “stop with 2 clean reps left,” and one concise technique cue. State warm-up sets, work sets, total logged sets, the MUST DO FIRST stopping point, and realistic durations for both the priority portion and the complete current-session workout.\n`;
     aiText += `3. Progression math: For every exercise, choose exactly one primary action from HOLD, ADD REPS, ADD LOAD, ADD SET, REDUCE LOAD, REDUCE SETS, INCREASE REST, CHANGE REP RANGE, TEST BASELINE, DELOAD, SUBSTITUTE EXERCISE, or STOP AND SEEK APPROPRIATE GUIDANCE. Show previous → next load, reps, and sets plus the percentage change. Explain the reason in one beginner-friendly sentence. The one-variable rule applies to the entire exercise: if total sets increase, no prescribed load anywhere in that exercise may increase; if any prescribed load increases, total sets may not increase. For ADD LOAD, use exactly one saved equipment increment unless the equipment cannot make that jump, in which case explain the available increment.\n`;
-    aiText += `4. Feasibility and complete coverage: Obey the hard time budget when supplied and keep MUST DO FIRST within the exported 90% duration target. Always display the rest of the complete workout under CONTINUE IF TIME with exact instructions, even when completing the entire list would exceed that day's time budget. Without a supplied budget, show the full estimated duration and do not shrink the exercise roster because the previous session ran out of time. Time changes order and stopping point only; it must not erase exercises or create catch-up volume.\n`;
+    aiText += `4. Feasibility and complete current-session coverage: Obey the hard time budget when supplied and keep MUST DO FIRST within the exported 90% duration target. Always display every remaining current-session exercise under CONTINUE IF TIME with exact instructions, even when completing that current-session list would exceed the day's time budget. Without a supplied budget, show the full estimated duration. Time changes order and stopping point only; history must not add exercises, and the plan must not create catch-up volume.\n`;
     aiText += `5. Evidence trace: For every decision, label Observed, Reported, Estimated, Inferred, Heuristic, and Missing/unknown information separately and give HIGH, MODERATE, LOW, or INSUFFICIENT confidence. Missing data must lower confidence rather than being invented. Never write “no pain reported/noted” under Reported when pain was simply not entered.\n`;
     aiText += `6. Autoregulation: Include simple green/yellow/red rules for readiness and a stop/substitution rule for pain or technique breakdown. A yellow or red trigger may only hold, reduce, skip, or stop the planned load; it must never tell the user to attempt a heavier set after an earlier ramp set was slow, shaky, painful, or technically poor. Ask only for truly missing information that would materially change safety or the plan.\n`;
-    aiText += `7. Final validation: The required plan is invalid if any Required coverage exercise disappears without an explicit safety/goal/equipment reason, if MUST DO FIRST exceeds the time target, if it counts failed or likely warm-up sets as successful progression work, if it uses the long-term goal as the next load, if it prescribes catch-up volume, if it increases exercise load and total sets together, if ADD LOAD skips the saved increment without an equipment reason, or if it recommends ADD LOAD/ADD SET for a pain-limited movement. The displayed complete-workout duration may exceed a hard time budget only when the priority stopping point remains within budget.\n`;
+    aiText += `7. Final validation: The required plan is invalid if any current-session exercise disappears without a permitted explicit reason, if it adds an exercise that is absent from the current export without a permitted labeled substitution, if it combines workout-day rosters, if MUST DO FIRST exceeds the time target, if it counts failed or likely warm-up sets as successful progression work, if it uses the long-term goal as the next load, if it prescribes catch-up volume, if it increases exercise load and total sets together, if ADD LOAD skips the saved increment without an equipment reason, or if it recommends ADD LOAD/ADD SET for a pain-limited movement. The displayed complete current-session workout may exceed a hard time budget only when the priority stopping point remains within budget.\n`;
     aiText += `8. Simplicity check: Rewrite anything a brand-new lifter would not understand. End with one sentence: “Follow this workout, log the result, and export again so I can calculate the next step.”\n`;
 
     if (navigator.clipboard) {
@@ -5678,8 +5556,7 @@ module.exports = {
   estimateE1rmFromSet,
   buildExerciseHighlightsForExport,
   getWorkoutExerciseRoster,
-  buildWorkoutCoverageReference,
-  getCoverageSetSummaries,
+  buildExerciseSelectionReference,
   computeConsistencyMetricsFromStats,
   appendUniqueHistoryLines,
   csvRow,

--- a/tests/exportSummary.test.js
+++ b/tests/exportSummary.test.js
@@ -4,8 +4,7 @@ const {
   buildExerciseHighlightsForExport,
   computeConsistencyMetricsFromStats,
   buildStrengthDecisionSupport,
-  buildWorkoutCoverageReference,
-  getCoverageSetSummaries,
+  buildExerciseSelectionReference,
   normalizeWorkoutMinutes,
   getLocalDateString,
   buildSessionPlanningContext,
@@ -213,67 +212,48 @@ describe('export summary helpers', () => {
     });
   });
 
-  it('restores exercises omitted from a time-limited workout using the best matching recent roster', () => {
+  it('uses only the current exported session to select next-workout exercises', () => {
     const current = normalizePayload({
       date: '2026-08-03',
       exercises: [
         { name: 'Bench Press', sets: [{ weight: 290, reps: 1 }] },
         { name: 'Chest-Supported Row', sets: [{ weight: 360, reps: 3 }] },
-      ],
-    });
-    const unrelatedLatest = normalizePayload({
-      date: '2026-08-01',
-      exercises: [
-        { name: 'Squat', sets: [{ weight: 255, reps: 5 }] },
-        { name: 'Romanian Deadlift', sets: [{ weight: 195, reps: 5 }] },
-      ],
-    });
-    const comparable = normalizePayload({
-      date: '2026-07-25',
-      exercises: [
-        { name: 'Bench Press', sets: [{ weight: 290, reps: 1 }] },
-        { name: 'Chest-Supported Row', sets: [{ weight: 360, reps: 3 }] },
-        { name: 'Wide-Grip Pulldown', sets: [{ weight: 150, reps: 5 }] },
-        { name: 'Chest Dip', sets: [{ weight: 70, reps: 6 }] },
+        { name: 'Shoulder Press', sets: [] },
       ],
     });
 
-    const coverage = buildWorkoutCoverageReference(current, [unrelatedLatest, comparable]);
-
-    expect(coverage.comparableDate).toBe('2026-07-25');
-    expect(coverage.requiredExercises).toEqual([
-      'Bench Press',
-      'Chest-Supported Row',
-      'Wide-Grip Pulldown',
-      'Chest Dip',
-    ]);
-    expect(coverage.possiblyOmittedExercises).toEqual([
-      'Wide-Grip Pulldown',
-      'Chest Dip',
-    ]);
-    expect(getCoverageSetSummaries(coverage.comparableSession, 'Chest Dip')).toEqual([
-      '70 lbs × 6',
-    ]);
+    expect(buildExerciseSelectionReference(current)).toEqual({
+      source: 'current_session_only',
+      currentExercises: [
+        'Bench Press',
+        'Chest-Supported Row',
+      ],
+      requiredExercises: [
+        'Bench Press',
+        'Chest-Supported Row',
+      ],
+    });
   });
 
-  it('keeps the current exercise order and deduplicates comparable coverage', () => {
+  it('does not let historical exercises expand the current-session roster', () => {
     const current = normalizePayload({
       exercises: [
         { name: 'Incline Bench Press', sets: [{ weight: 225, reps: 3 }] },
         { name: 'Bench Press', sets: [{ weight: 275, reps: 1 }] },
       ],
     });
-    const previous = normalizePayload({
+    const historyThatMustNotControlSelection = normalizePayload({
       exercises: [
-        { name: 'bench press', sets: [{ weight: 275, reps: 1 }] },
+        { name: 'Bench Press', sets: [{ weight: 270, reps: 2 }] },
         { name: 'Chest Dip', sets: [{ weight: 70, reps: 5 }] },
+        { name: 'Shoulder Press', sets: [{ weight: 135, reps: 5 }] },
       ],
     });
 
-    expect(buildWorkoutCoverageReference(current, [previous]).requiredExercises).toEqual([
+    expect(historyThatMustNotControlSelection.exercises).toHaveLength(3);
+    expect(buildExerciseSelectionReference(current).requiredExercises).toEqual([
       'Incline Bench Press',
       'Bench Press',
-      'Chest Dip',
     ]);
   });
 });


### PR DESCRIPTION
## What changed

- Made the current exported session the exclusive source of next-workout exercise selection.
- Historical workouts can still calculate progression for exercises that are present in the current session, but cannot add exercises.
- Removed v1.6's best-matching historical roster recovery.
- Preserved complete prescriptions for every exercise actually performed in the current session, including time-priority sections.
- Excluded selected exercises with no logged sets from the required roster.
- Added explicit substitution rules for user requests, saved post-goal instructions, pain, safety, and unavailable equipment.
- Released as v1.7.

## Why

The historical roster recovery introduced in v1.6 could combine exercises from different workout days. The intended rule is: historical data controls progression; the current export controls exercise selection.

## Validation

- `npm test -- --runInBand` — 65 tests passed
- `node --check script.js`
- `git diff --check`